### PR TITLE
fix: update module path to github.com/khaiql/parley

### DIFF
--- a/cmd/parley/main.go
+++ b/cmd/parley/main.go
@@ -11,11 +11,11 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
 
-	"github.com/sle/parley/internal/client"
-	"github.com/sle/parley/internal/driver"
-	"github.com/sle/parley/internal/protocol"
-	"github.com/sle/parley/internal/server"
-	"github.com/sle/parley/internal/tui"
+	"github.com/khaiql/parley/internal/client"
+	"github.com/khaiql/parley/internal/driver"
+	"github.com/khaiql/parley/internal/protocol"
+	"github.com/khaiql/parley/internal/server"
+	"github.com/khaiql/parley/internal/tui"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,18 @@
-module github.com/sle/parley
+module github.com/khaiql/parley
 
 go 1.26.1
 
 require (
+	github.com/charmbracelet/bubbles v1.0.0
+	github.com/charmbracelet/bubbletea v1.3.10
+	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/spf13/cobra v1.10.2
+)
+
+require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
-	github.com/charmbracelet/bubbles v1.0.0 // indirect
-	github.com/charmbracelet/bubbletea v1.3.10 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
-	github.com/charmbracelet/lipgloss v1.1.0 // indirect
 	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
@@ -25,7 +29,6 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
-	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sys v0.38.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,11 @@
+github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
+github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3vj1nolY=
+github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
 github.com/charmbracelet/bubbles v1.0.0 h1:12J8/ak/uCZEMQ6KU7pcfwceyjLlWsDLAxB5fXonfvc=
 github.com/charmbracelet/bubbles v1.0.0/go.mod h1:9d/Zd5GdnauMI5ivUIVisuEm3ave1XwXtD1ckyV6r3E=
 github.com/charmbracelet/bubbletea v1.3.10 h1:otUDHWMMzQSB0Pkc87rm691KZ3SWa4KUlvF9nRvCICw=
@@ -51,6 +55,8 @@ github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -5,7 +5,7 @@ import (
 	"bufio"
 	"net"
 
-	"github.com/sle/parley/internal/protocol"
+	"github.com/khaiql/parley/internal/protocol"
 )
 
 // Client manages a single TCP connection to a Parley server.

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sle/parley/internal/client"
-	"github.com/sle/parley/internal/protocol"
-	"github.com/sle/parley/internal/server"
+	"github.com/khaiql/parley/internal/client"
+	"github.com/khaiql/parley/internal/protocol"
+	"github.com/khaiql/parley/internal/server"
 )
 
 // drain reads up to n messages from ch within a timeout, returning what it collected.

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sle/parley/internal/client"
-	"github.com/sle/parley/internal/protocol"
-	"github.com/sle/parley/internal/server"
+	"github.com/khaiql/parley/internal/client"
+	"github.com/khaiql/parley/internal/protocol"
+	"github.com/khaiql/parley/internal/server"
 )
 
 // readMsg reads the next message from the client's incoming channel, failing

--- a/internal/protocol/protocol_test.go
+++ b/internal/protocol/protocol_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sle/parley/internal/protocol"
+	"github.com/khaiql/parley/internal/protocol"
 )
 
 func TestEncodeLineEndsWithNewline(t *testing.T) {

--- a/internal/server/persistence.go
+++ b/internal/server/persistence.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/sle/parley/internal/protocol"
+	"github.com/khaiql/parley/internal/protocol"
 )
 
 // RoomData is the JSON representation of a Room's metadata.

--- a/internal/server/persistence_test.go
+++ b/internal/server/persistence_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sle/parley/internal/protocol"
+	"github.com/khaiql/parley/internal/protocol"
 )
 
 func TestSaveAndLoadRoom(t *testing.T) {

--- a/internal/server/room.go
+++ b/internal/server/room.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/sle/parley/internal/protocol"
+	"github.com/khaiql/parley/internal/protocol"
 )
 
 // Room holds the shared state for a single chat room.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -7,7 +7,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/sle/parley/internal/protocol"
+	"github.com/khaiql/parley/internal/protocol"
 )
 
 const scanBufSize = 1024 * 1024 // 1 MB

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sle/parley/internal/protocol"
-	"github.com/sle/parley/internal/server"
+	"github.com/khaiql/parley/internal/protocol"
+	"github.com/khaiql/parley/internal/server"
 )
 
 const bufSize = 1024 * 1024 // 1 MB

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -7,7 +7,7 @@ import (
 	"github.com/charmbracelet/bubbles/textarea"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/sle/parley/internal/protocol"
+	"github.com/khaiql/parley/internal/protocol"
 )
 
 const sidebarWidth = 28

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/sle/parley/internal/protocol"
+	"github.com/khaiql/parley/internal/protocol"
 )
 
 // ---- parseMentions -----------------------------------------------------------

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -7,7 +7,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/bubbles/viewport"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/sle/parley/internal/protocol"
+	"github.com/khaiql/parley/internal/protocol"
 )
 
 // Chat wraps a viewport and holds the message history.

--- a/internal/tui/chat_test.go
+++ b/internal/tui/chat_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sle/parley/internal/protocol"
+	"github.com/khaiql/parley/internal/protocol"
 )
 
 func TestExtractText(t *testing.T) {

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/sle/parley/internal/protocol"
+	"github.com/khaiql/parley/internal/protocol"
 )
 
 // Sidebar renders the participant list panel.

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -3,7 +3,7 @@ package tui
 import (
 	"testing"
 
-	"github.com/sle/parley/internal/protocol"
+	"github.com/khaiql/parley/internal/protocol"
 )
 
 func TestSidebarAddParticipant(t *testing.T) {

--- a/internal/tui/visual_test.go
+++ b/internal/tui/visual_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/sle/parley/internal/protocol"
+	"github.com/khaiql/parley/internal/protocol"
 )
 
 const updateGolden = false // set to true to regenerate golden files


### PR DESCRIPTION
Fixes #1. Changes module path from github.com/sle/parley to github.com/khaiql/parley and updates all imports.

## Changes

- Updated go.mod module declaration
- Updated all imports across 19 .go files (including test files)
- Ran go mod tidy to update go.sum
- All tests pass: go test ./... -timeout 30s -race
- go vet ./... shows no issues
- go build ./... succeeds

## Files Modified

- go.mod
- go.sum  
- cmd/parley/main.go
- internal/client/client.go
- internal/client/client_test.go
- internal/integration_test.go
- internal/protocol/protocol_test.go
- internal/server/room.go
- internal/server/server.go
- internal/server/server_test.go
- internal/server/persistence.go
- internal/server/persistence_test.go
- internal/tui/app.go
- internal/tui/app_test.go
- internal/tui/chat.go
- internal/tui/chat_test.go
- internal/tui/sidebar.go
- internal/tui/sidebar_test.go
- internal/tui/visual_test.go