### PR TITLE
fix: use atomic counter for unique message IDs

### DIFF
--- a/internal/server/generateid_test.go
+++ b/internal/server/generateid_test.go
@@ -1,0 +1,40 @@
+package server
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestGenerateIDUniqueness(t *testing.T) {
+	const goroutines = 10
+	const idsPerGoroutine = 1000
+
+	var ids sync.Map
+	var wg sync.WaitGroup
+	duplicates := make(chan string, goroutines*idsPerGoroutine)
+
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < idsPerGoroutine; i++ {
+				id := generateID()
+				if _, loaded := ids.LoadOrStore(id, struct{}{}); loaded {
+					duplicates <- id
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(duplicates)
+
+	var dups []string
+	for id := range duplicates {
+		dups = append(dups, id)
+	}
+
+	if len(dups) > 0 {
+		t.Errorf("generateID() produced %d duplicate IDs: first duplicate = %q", len(dups), dups[0])
+	}
+}

--- a/internal/server/room.go
+++ b/internal/server/room.go
@@ -3,6 +3,7 @@ package server
 import (
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/khaiql/parley/internal/protocol"
@@ -174,7 +175,9 @@ func (r *Room) GetParticipants() []*ClientConn {
 	return out
 }
 
-// generateID returns a simple timestamp-based ID.
+var msgCounter uint64
+
+// generateID returns a unique message ID using an atomic counter.
 func generateID() string {
-	return fmt.Sprintf("%d", time.Now().UnixNano())
+	return fmt.Sprintf("msg-%d", atomic.AddUint64(&msgCounter, 1))
 }


### PR DESCRIPTION
## Summary

- Replaces `time.Now().UnixNano()` in `generateID()` with an atomic `uint64` counter, eliminating duplicate IDs under concurrent load
- Adds `sync/atomic` import to `internal/server/room.go`
- Adds `TestGenerateIDUniqueness` in `internal/server/generateid_test.go`: 10 goroutines × 1000 calls verified unique via `sync.Map`

## Test plan

- [x] RED: ran test against old implementation — produced ~2000 duplicates per run
- [x] GREEN: ran test against new implementation — 0 duplicates across 5 `-count=5` runs
- [x] `go test -race ./internal/server/ -timeout 30s` passes

Fixes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)