### PR TITLE
fix: client double-close race and incoming channel leak

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -4,15 +4,17 @@ package client
 import (
 	"bufio"
 	"net"
+	"sync"
 
 	"github.com/khaiql/parley/internal/protocol"
 )
 
 // Client manages a single TCP connection to a Parley server.
 type Client struct {
-	conn     net.Conn
-	incoming chan *protocol.RawMessage
-	done     chan struct{}
+	conn      net.Conn
+	incoming  chan *protocol.RawMessage
+	done      chan struct{}
+	closeOnce sync.Once
 }
 
 // New dials the server at addr, starts the read loop goroutine, and returns
@@ -63,20 +65,18 @@ func (c *Client) Send(content protocol.Content, mentions []string) error {
 }
 
 // Close signals the read loop to stop and closes the underlying connection.
+// It is safe to call Close concurrently or more than once.
 func (c *Client) Close() error {
-	select {
-	case <-c.done:
-		// already closed
-	default:
-		close(c.done)
-	}
+	c.closeOnce.Do(func() { close(c.done) })
 	return c.conn.Close()
 }
 
 // readLoop reads NDJSON lines from the connection, decodes each as a RawMessage,
 // and sends it to the incoming channel. It exits when the connection is closed
-// or the done channel is closed.
+// or the done channel is closed. It closes the incoming channel on exit so that
+// consumers using range will unblock.
 func (c *Client) readLoop() {
+	defer close(c.incoming)
 	sc := bufio.NewScanner(c.conn)
 	for sc.Scan() {
 		line := sc.Bytes()

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -135,6 +135,64 @@ func TestClientSendsAndReceives(t *testing.T) {
 	}
 }
 
+// TestClientConcurrentClose verifies that calling Close() from two goroutines
+// simultaneously does not panic.
+func TestClientConcurrentClose(t *testing.T) {
+	srv, err := server.New("127.0.0.1:0", "test-room")
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+	defer srv.Close()
+	go srv.Serve()
+
+	c, err := client.New(srv.Addr())
+	if err != nil {
+		t.Fatalf("client.New: %v", err)
+	}
+
+	// Call Close() concurrently from two goroutines — must not panic.
+	done := make(chan struct{})
+	go func() {
+		c.Close()
+		close(done)
+	}()
+	c.Close()
+	<-done
+}
+
+// TestClientIncomingClosesAfterDisconnect verifies that ranging over Incoming()
+// terminates (does not hang) after Close() is called.
+func TestClientIncomingClosesAfterDisconnect(t *testing.T) {
+	srv, err := server.New("127.0.0.1:0", "test-room")
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+	defer srv.Close()
+	go srv.Serve()
+
+	c, err := client.New(srv.Addr())
+	if err != nil {
+		t.Fatalf("client.New: %v", err)
+	}
+
+	rangeFinished := make(chan struct{})
+	go func() {
+		// range should unblock once incoming is closed.
+		for range c.Incoming() {
+		}
+		close(rangeFinished)
+	}()
+
+	c.Close()
+
+	select {
+	case <-rangeFinished:
+		// success — range terminated
+	case <-time.After(3 * time.Second):
+		t.Fatal("range c.Incoming() did not terminate after Close()")
+	}
+}
+
 // methodsOf extracts method names from a slice of RawMessages for error output.
 func methodsOf(msgs []*protocol.RawMessage) []string {
 	out := make([]string, len(msgs))


### PR DESCRIPTION
## Summary

- Add `closeOnce sync.Once` to `Client` struct and use it in `Close()` so concurrent calls never panic on a double-close of the `done` channel
- Add `defer close(c.incoming)` at the end of `readLoop` so consumers using `range c.Incoming()` unblock naturally when the connection ends
- Add two tests driven by strict TDD: `TestClientConcurrentClose` and `TestClientIncomingClosesAfterDisconnect`

Fixes #2

## Test plan

- [ ] `go test -race ./internal/client/ -timeout 30s` — all tests pass, no race detected
- [ ] `go test ./... -timeout 30s -race` — all packages pass (pre-existing `TestGenerateIDUniqueness` flake in server package is unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)