### PR TITLE
fix: add timeout to join room.state wait loop

### DIFF
--- a/cmd/parley/main.go
+++ b/cmd/parley/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
@@ -176,11 +177,21 @@ func runJoin(cmd *cobra.Command, args []string) error {
 
 	// Wait for room.state to get topic and participants.
 	var roomState protocol.RoomStateParams
-	for msg := range c.Incoming() {
-		if msg.Method == "room.state" {
-			if err := json.Unmarshal(msg.Params, &roomState); err == nil {
-				break
+	timeout := time.After(5 * time.Second)
+	found := false
+	for !found {
+		select {
+		case msg, ok := <-c.Incoming():
+			if !ok {
+				return fmt.Errorf("join: connection closed before receiving room state")
 			}
+			if msg.Method == "room.state" {
+				if err := json.Unmarshal(msg.Params, &roomState); err == nil {
+					found = true
+				}
+			}
+		case <-timeout:
+			return fmt.Errorf("join: timeout: server did not send room state within 5 seconds")
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Replaces the unbounded `for msg := range c.Incoming()` loop in `runJoin()` with a `select` + `time.After(5 * time.Second)` pattern
- Returns a clear error if the connection closes before `room.state` arrives
- Returns a clear error if the server doesn't send `room.state` within 5 seconds

Fixes #11

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -timeout 30s -race` — all packages pass (pre-existing unrelated failure in `internal/server` is unchanged)
- Manual: connect to a server that never sends `room.state`; verify the join command exits with the timeout error after ~5s

🤖 Generated with [Claude Code](https://claude.com/claude-code)