### PR TITLE
Clean up dead code and duplication (#13)

### DIFF
--- a/cmd/parley/main.go
+++ b/cmd/parley/main.go
@@ -273,7 +273,7 @@ func runJoin(cmd *cobra.Command, args []string) error {
 			case driver.EventDone:
 				text := strings.TrimSpace(accumulated.String())
 				if text != "" {
-					mentions := parseMentions(text)
+					mentions := protocol.ParseMentions(text)
 					_ = c.Send(protocol.Content{Type: "text", Text: text}, mentions)
 				}
 				accumulated.Reset()
@@ -296,15 +296,4 @@ func contentText(content []protocol.Content) string {
 		}
 	}
 	return strings.Join(parts, "")
-}
-
-// parseMentions extracts @mention tokens from a message string.
-func parseMentions(text string) []string {
-	var mentions []string
-	for _, word := range strings.Fields(text) {
-		if strings.HasPrefix(word, "@") && len(word) > 1 {
-			mentions = append(mentions, word[1:])
-		}
-	}
-	return mentions
 }

--- a/internal/driver/claude.go
+++ b/internal/driver/claude.go
@@ -271,36 +271,6 @@ func parseStreamEvent(raw claudeRawEvent) (AgentEvent, bool) {
 	}
 }
 
-// parseAssistantEvent extracts text and tool-use content from a non-streaming assistant event.
-func parseAssistantEvent(raw claudeRawEvent) (AgentEvent, bool) {
-	if raw.Message == nil {
-		return AgentEvent{}, false
-	}
-	var msg claudeMessage
-	if err := json.Unmarshal(raw.Message, &msg); err != nil {
-		return AgentEvent{}, false
-	}
-
-	var texts []string
-	for _, item := range msg.Content {
-		switch item.Type {
-		case "text":
-			if item.Text != "" {
-				texts = append(texts, item.Text)
-			}
-		case "thinking":
-			return AgentEvent{Type: EventThinking, Text: item.Thinking}, true
-		case "tool_use":
-			return AgentEvent{Type: EventToolUse, ToolName: item.Name}, true
-		}
-	}
-
-	if len(texts) > 0 {
-		return AgentEvent{Type: EventText, Text: strings.Join(texts, "")}, true
-	}
-	return AgentEvent{}, false
-}
-
 // ---------------------------------------------------------------------------
 // BuildSystemPrompt
 // ---------------------------------------------------------------------------

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -4,6 +4,7 @@ package protocol
 
 import (
 	"encoding/json"
+	"strings"
 	"time"
 )
 
@@ -117,6 +118,20 @@ type RoomStateParams struct {
 }
 
 // ---- Helper functions -------------------------------------------------------
+
+// ParseMentions extracts @mention tokens from a message string.
+// A mention is any whitespace-delimited token that starts with "@" and has at
+// least one additional character. The returned slice contains the names without
+// the leading "@".
+func ParseMentions(text string) []string {
+	var mentions []string
+	for _, word := range strings.Fields(text) {
+		if strings.HasPrefix(word, "@") && len(word) > 1 {
+			mentions = append(mentions, word[1:])
+		}
+	}
+	return mentions
+}
 
 // EncodeLine marshals v to JSON and appends a newline, returning the result.
 // This produces one NDJSON line suitable for writing to a TCP stream.

--- a/internal/protocol/protocol_test.go
+++ b/internal/protocol/protocol_test.go
@@ -110,6 +110,38 @@ func TestNotificationRoundTrip(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// TestParseMentions
+// ---------------------------------------------------------------------------
+
+func TestParseMentions_ExtractsAtMentions(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{"no mentions", "hello world", nil},
+		{"single mention", "@alice hello", []string{"alice"}},
+		{"multiple mentions", "@alice and @bob should look", []string{"alice", "bob"}},
+		{"bare at sign skipped", "@ hello", nil},
+		{"mention with punctuation attached", "@alice: hello", []string{"alice:"}},
+		{"empty string", "", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := protocol.ParseMentions(tt.input)
+			if len(got) != len(tt.want) {
+				t.Fatalf("ParseMentions(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("ParseMentions(%q)[%d] = %q, want %q", tt.input, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestJoinParamsEncodeDecodeRoundTrip(t *testing.T) {
 	params := protocol.JoinParams{
 		Name:      "agent-x",

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -82,7 +82,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				text := strings.TrimSpace(a.input.Value())
 				if text != "" {
 					a.input.Reset()
-					mentions := parseMentions(text)
+					mentions := protocol.ParseMentions(text)
 					if a.sendFn != nil {
 						a.sendFn(text, mentions)
 					}
@@ -184,15 +184,4 @@ func (a *App) handleServerMsg(raw *protocol.RawMessage) {
 			a.sidebar.RemoveParticipant(params.Name)
 		}
 	}
-}
-
-// parseMentions extracts @mention tokens from a message string.
-func parseMentions(text string) []string {
-	var mentions []string
-	for _, word := range strings.Fields(text) {
-		if strings.HasPrefix(word, "@") && len(word) > 1 {
-			mentions = append(mentions, word[1:])
-		}
-	}
-	return mentions
 }

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -7,48 +7,6 @@ import (
 	"github.com/khaiql/parley/internal/protocol"
 )
 
-// ---- parseMentions -----------------------------------------------------------
-
-func TestParseMentions_None(t *testing.T) {
-	mentions := parseMentions("hello world, no mentions here")
-	if len(mentions) != 0 {
-		t.Fatalf("expected no mentions, got %v", mentions)
-	}
-}
-
-func TestParseMentions_Single(t *testing.T) {
-	mentions := parseMentions("hey @alice how are you")
-	if len(mentions) != 1 || mentions[0] != "alice" {
-		t.Fatalf("expected [alice], got %v", mentions)
-	}
-}
-
-func TestParseMentions_Multiple(t *testing.T) {
-	mentions := parseMentions("@alice and @bob please review")
-	if len(mentions) != 2 {
-		t.Fatalf("expected 2 mentions, got %v", mentions)
-	}
-	if mentions[0] != "alice" || mentions[1] != "bob" {
-		t.Errorf("unexpected mentions: %v", mentions)
-	}
-}
-
-func TestParseMentions_AtSignAlone(t *testing.T) {
-	// A bare "@" should not count as a mention.
-	mentions := parseMentions("email me @ home")
-	if len(mentions) != 0 {
-		t.Fatalf("expected no mentions, got %v", mentions)
-	}
-}
-
-func TestParseMentions_LeadingAtWithPunctuation(t *testing.T) {
-	// The whole token starting with @ is captured as-is (minus the @).
-	mentions := parseMentions("@alice!")
-	if len(mentions) != 1 || mentions[0] != "alice!" {
-		t.Fatalf("expected [alice!], got %v", mentions)
-	}
-}
-
 // ---- handleServerMsg ---------------------------------------------------------
 
 func makeApp() App {

--- a/internal/tui/topbar.go
+++ b/internal/tui/topbar.go
@@ -57,9 +57,6 @@ func (t TopBar) View() string {
 	leftGap := (spacerRight) / 2
 	rightGap := spacerRight - leftGap
 
-	leftPad := lipgloss.NewStyle().Width(leftLen + leftGap).Render(appName)
-	_ = leftPad
-
 	line := appName +
 		lipgloss.NewStyle().Width(leftGap).Render("") +
 		middle +


### PR DESCRIPTION
## Summary

- **Remove dead `parseAssistantEvent`** — assistant events are already skipped in `parseLine`; this function was never called
- **Move `parseMentions` to `protocol.ParseMentions`** — eliminates duplication between `cmd/parley/main.go` and `internal/tui/app.go`; added test in `protocol_test.go` (TDD), removed local copies and duplicate tui tests
- **Remove dead `leftPad` in topbar** — computed then immediately discarded with `_ = leftPad`
- **Run `go mod tidy` and `go vet`** — clean

## Test plan

- [x] `go test ./... -timeout 30s -race` — all pass
- [x] `go vet ./...` — no issues
- [x] `ParseMentions` tested in `internal/protocol/protocol_test.go`
- [x] Verified `parseAssistantEvent` had no callers before removal

Fixes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)