### PR TITLE
feat: wrap long message text to viewport width

### DIFF
--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -68,16 +68,24 @@ func (c Chat) View() string {
 func renderMessage(msg protocol.MessageParams, width int) string {
 	text := extractText(msg.Content)
 
+	// Leave at least 1 column for content; body is capped at the viewport
+	// width so long text wraps instead of overflowing.
+	bodyWidth := width
+	if bodyWidth < 1 {
+		bodyWidth = 1
+	}
+	bodyStyle := lipgloss.NewStyle().Foreground(colorText).Width(bodyWidth)
+
 	switch msg.Source {
 	case "system", "":
 		if msg.Source == "" && msg.Role == "system" {
-			return systemMsgStyle.Render(fmt.Sprintf("[system] %s", text))
+			return systemMsgStyle.Width(bodyWidth).Render(fmt.Sprintf("[system] %s", text))
 		}
 		if msg.Source == "system" {
-			return systemMsgStyle.Render(fmt.Sprintf("[system] %s", text))
+			return systemMsgStyle.Width(bodyWidth).Render(fmt.Sprintf("[system] %s", text))
 		}
 		// Unknown — render as plain text.
-		return lipgloss.NewStyle().Foreground(colorText).Render(text)
+		return bodyStyle.Render(text)
 
 	case "human":
 		ts := formatTimestamp(msg)
@@ -87,7 +95,7 @@ func renderMessage(msg protocol.MessageParams, width int) string {
 			" ",
 			timestampStyle.Render(ts),
 		)
-		return header + "\n" + lipgloss.NewStyle().Foreground(colorText).Render(text)
+		return header + "\n" + bodyStyle.Render(text)
 
 	default:
 		// agent
@@ -104,7 +112,7 @@ func renderMessage(msg protocol.MessageParams, width int) string {
 			" ",
 			timestampStyle.Render(ts),
 		)
-		return header + "\n" + lipgloss.NewStyle().Foreground(colorText).Render(text)
+		return header + "\n" + bodyStyle.Render(text)
 	}
 }
 

--- a/internal/tui/chat_test.go
+++ b/internal/tui/chat_test.go
@@ -1,11 +1,21 @@
 package tui
 
 import (
+	"regexp"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/khaiql/parley/internal/protocol"
 )
+
+// ansiEscapeRegex strips ANSI escape sequences from a string so we can measure
+// visible character width.
+var ansiEscapeRegex = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+func stripANSI(s string) string {
+	return ansiEscapeRegex.ReplaceAllString(s, "")
+}
 
 func TestExtractText(t *testing.T) {
 	tests := []struct {
@@ -166,4 +176,35 @@ func indexOf(s, sub string) int {
 		}
 	}
 	return -1
+}
+
+func TestRenderMessageWrapsLongText(t *testing.T) {
+	// Build a 200-character message body (sentence with many short words).
+	longText := strings.Repeat("word ", 40) // "word word word ..." = 199 chars after TrimSpace
+	longText = strings.TrimSpace(longText)
+
+	msg := protocol.MessageParams{
+		From:   "alice",
+		Source: "human",
+		Role:   "human",
+		Content: []protocol.Content{
+			{Type: "text", Text: longText},
+		},
+		Timestamp: time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+	}
+
+	const width = 80
+	rendered := renderMessage(msg, width)
+
+	lines := strings.Split(rendered, "\n")
+	if len(lines) <= 1 {
+		t.Errorf("expected multiple lines for 200-char message at width %d, got %d line(s)", width, len(lines))
+	}
+
+	for i, line := range lines {
+		visible := stripANSI(line)
+		if len(visible) > width {
+			t.Errorf("line %d exceeds width %d: len=%d %q", i, width, len(visible), visible)
+		}
+	}
 }

--- a/internal/tui/testdata/layout_40x10.golden
+++ b/internal/tui/testdata/layout_40x10.golden
@@ -1,11 +1,11 @@
  parley        test topic         :1234  
-[system] Ali│ participants               
-sle 10:31   │                            
-Hello everyo│ sle                        
-            │                            
-            │ Alice  backend             
-            │   claude                   
-            │   /home/alice/project      
+[system]    │ participants               
+Alice has   │                            
+joined —    │ sle                        
+backend     │                            
+sle 10:31   │ Alice  backend             
+Hello       │   claude                   
+everyone    │   /home/alice/project      
             │                            
 ──────────────────────────────────────── 
  ┃ Type a message… (Enter to send)       


### PR DESCRIPTION
## Summary

- Long messages in the chat area no longer overflow the viewport; they wrap at the chat width
- `renderMessage` now uses `lipgloss.NewStyle().Width(bodyWidth)` to constrain body text
- Applies to human, agent, and system message types
- Updated golden snapshot for the 40x10 visual regression test (system message now wraps at narrow widths)

## Changes

- `internal/tui/chat.go`: compute `bodyWidth = width` (min 1) and apply `.Width(bodyWidth)` to the body style and system message style
- `internal/tui/chat_test.go`: new `TestRenderMessageWrapsLongText` test — renders a 200-char message at width 80 and asserts multiple lines, none exceeding 80 visible chars (ANSI stripped)
- `internal/tui/testdata/layout_40x10.golden`: updated to reflect wrapping at narrow width

Fixes #7

## Test plan

- [ ] `go test ./internal/tui/ -run TestRenderMessageWrapsLongText` passes (GREEN)
- [ ] `go test ./... -timeout 30s -race` all green
- [ ] Visual golden for 40x10 shows system message wrapping correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)