### PR TITLE
feat(tui): input box improvements for agent and human modes

### DIFF
--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -90,23 +90,34 @@ func (i *Input) Update(msg tea.Msg) tea.Cmd {
 	return cmd
 }
 
+// contentWidth returns the usable text width inside the input box, accounting
+// for the border and padding applied by inputStyle.
+func (i Input) contentWidth() int {
+	// inputStyle has Padding(0,1) on each side = 2 chars, no left/right border.
+	w := i.width - 2
+	if w < 1 {
+		w = 1
+	}
+	return w
+}
+
 // View renders the input area.
 func (i Input) View() string {
 	var content string
+	cw := i.contentWidth()
 	switch i.mode {
 	case InputModeAgent:
 		if i.agentStatus != "" {
 			// Status (thinking, tool use) takes priority — shows what agent is doing
-			content = systemMsgStyle.Render(i.agentStatus)
+			content = systemMsgStyle.Width(cw).Render(i.agentStatus)
 		} else if i.agentText != "" {
-			// Show the last 2 lines of streaming text
-			lines := strings.Split(i.agentText, "\n")
-			start := len(lines) - 2
-			if start < 0 {
-				start = 0
-			}
-			visible := strings.Join(lines[start:], "\n")
-			content = lipgloss.NewStyle().Foreground(colorAgent).Render(visible) +
+			// Wrap the streaming text to the content width, then show the last
+			// visible line(s) with a blinking cursor indicator at the end.
+			wrapped := lipgloss.NewStyle().Width(cw).Render(i.agentText)
+			lines := strings.Split(wrapped, "\n")
+			// Keep only the last line for the single-row input display.
+			lastLine := lines[len(lines)-1]
+			content = lipgloss.NewStyle().Foreground(colorAgent).Render(lastLine) +
 				systemMsgStyle.Render(" ▊")
 		} else {
 			content = lipgloss.NewStyle().Foreground(colorDimText).Render("(waiting for messages…)")

--- a/internal/tui/input_test.go
+++ b/internal/tui/input_test.go
@@ -1,0 +1,125 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestInputAgentMode_EmptyShowsWaiting verifies that when in agent mode with no
+// text or status, the waiting message is rendered.
+func TestInputAgentMode_EmptyShowsWaiting(t *testing.T) {
+	inp := NewInput()
+	inp.SetMode(InputModeAgent)
+	inp.SetWidth(80)
+
+	view := inp.View()
+	plain := stripANSI(view)
+
+	if !strings.Contains(plain, "(waiting for messages…)") {
+		t.Errorf("expected waiting message in agent mode with no text, got:\n%s", plain)
+	}
+}
+
+// TestInputAgentMode_StatusTakesPriority verifies that a status message is shown
+// when both agentStatus and agentText are set.
+func TestInputAgentMode_StatusTakesPriority(t *testing.T) {
+	inp := NewInput()
+	inp.SetMode(InputModeAgent)
+	inp.SetWidth(80)
+	inp.SetAgentText("some streaming text")
+	inp.SetAgentStatus("thinking...")
+
+	view := inp.View()
+	plain := stripANSI(view)
+
+	if !strings.Contains(plain, "thinking...") {
+		t.Errorf("expected status 'thinking...' in view, got:\n%s", plain)
+	}
+	if strings.Contains(plain, "some streaming text") {
+		t.Errorf("streaming text should NOT appear when status is set, got:\n%s", plain)
+	}
+}
+
+// TestInputAgentMode_LongTextWraps verifies that text longer than the input
+// width is wrapped so that no rendered line exceeds the total width.
+func TestInputAgentMode_LongTextWraps(t *testing.T) {
+	inp := NewInput()
+	inp.SetMode(InputModeAgent)
+	width := 40
+	inp.SetWidth(width)
+
+	// Build text that is definitely wider than the input area (width - padding/border).
+	longLine := strings.Repeat("abcdefghij", 10) // 100 chars, should wrap
+	inp.SetAgentText(longLine)
+
+	view := inp.View()
+	plain := stripANSI(view)
+
+	// Each line should fit within total width (using rune count for Unicode safety).
+	lines := strings.Split(plain, "\n")
+	for _, line := range lines {
+		runes := []rune(line)
+		if len(runes) > width {
+			t.Errorf("line exceeds width %d: %q (runes=%d)", width, line, len(runes))
+		}
+	}
+}
+
+// TestInputAgentMode_CursorIndicator verifies that a blinking cursor indicator
+// (▊) appears at the end of streaming text.
+func TestInputAgentMode_CursorIndicator(t *testing.T) {
+	inp := NewInput()
+	inp.SetMode(InputModeAgent)
+	inp.SetWidth(80)
+	inp.SetAgentText("hello world")
+
+	view := inp.View()
+	// The cursor character should be present in the raw view (may have ANSI codes around it).
+	if !strings.Contains(view, "▊") {
+		t.Errorf("expected cursor indicator ▊ in agent mode with text, got:\n%s", view)
+	}
+}
+
+// TestInputHumanMode_Reset verifies that Reset clears the textarea value.
+func TestInputHumanMode_Reset(t *testing.T) {
+	inp := NewInput()
+	inp.SetMode(InputModeHuman)
+	// textarea doesn't expose direct setting easily; test that Reset produces empty value.
+	inp.Reset()
+	if inp.Value() != "" {
+		t.Errorf("expected empty value after Reset, got: %q", inp.Value())
+	}
+}
+
+// TestInputHumanMode_PlaceholderVisible verifies that the human-mode view
+// contains some visible content (the textarea with placeholder).
+func TestInputHumanMode_PlaceholderVisible(t *testing.T) {
+	inp := NewInput()
+	inp.SetMode(InputModeHuman)
+	inp.SetWidth(80)
+
+	view := inp.View()
+	if len(view) == 0 {
+		t.Error("expected non-empty view in human mode")
+	}
+}
+
+// TestInputAgentMode_SetAgentTextClearsStatus verifies that calling SetAgentText
+// with a non-empty value clears the status.
+func TestInputAgentMode_SetAgentTextClearsStatus(t *testing.T) {
+	inp := NewInput()
+	inp.SetMode(InputModeAgent)
+	inp.SetWidth(80)
+	inp.SetAgentStatus("thinking...")
+	inp.SetAgentText("new text")
+
+	view := inp.View()
+	plain := stripANSI(view)
+
+	if strings.Contains(plain, "thinking...") {
+		t.Errorf("status should be cleared after SetAgentText with text, got:\n%s", plain)
+	}
+	if !strings.Contains(plain, "new text") {
+		t.Errorf("expected 'new text' in view, got:\n%s", plain)
+	}
+}


### PR DESCRIPTION
## Summary

- Agent mode wraps streaming text to the content width before showing the last line with a `▊` cursor indicator
- Agent mode shows `(waiting for messages…)` in dim text when no text or status is set
- Status messages (thinking, tool use) now use `Width(cw)` for consistent rendering
- Added `contentWidth()` helper that accounts for `inputStyle` padding
- New `input_test.go` with 7 unit tests covering all agent/human mode scenarios

## Test plan

- [ ] All unit tests pass: `go test ./internal/tui/... -run TestInput -v`
- [ ] Full test suite passes with race detector: `go test ./... -timeout 30s -race`
- [ ] Golden files unchanged (human mode input box rendering unaffected)
- [ ] Manually verify agent mode: long streaming text stays within input box bounds

Fixes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)