### PR TITLE
feat: move agent status to sidebar

### DIFF
--- a/cmd/parley/main.go
+++ b/cmd/parley/main.go
@@ -263,13 +263,13 @@ func runJoin(cmd *cobra.Command, args []string) error {
 				accumulated.WriteString(event.Text)
 				p.Send(tui.AgentTypingMsg{Text: accumulated.String()})
 			case driver.EventThinking:
-				p.Send(tui.AgentStatusMsg{Status: "thinking…"})
+				_ = c.SendStatus(joinName, "thinking…")
 			case driver.EventToolUse:
 				status := "using tool…"
 				if event.ToolName != "" {
-					status = fmt.Sprintf("using tool: %s…", event.ToolName)
+					status = fmt.Sprintf("using: %s…", event.ToolName)
 				}
-				p.Send(tui.AgentStatusMsg{Status: status})
+				_ = c.SendStatus(joinName, status)
 			case driver.EventDone:
 				text := strings.TrimSpace(accumulated.String())
 				if text != "" {
@@ -278,7 +278,7 @@ func runJoin(cmd *cobra.Command, args []string) error {
 				}
 				accumulated.Reset()
 				p.Send(tui.AgentTypingMsg{Text: ""})
-				p.Send(tui.AgentStatusMsg{Status: ""})
+				_ = c.SendStatus(joinName, "")
 			}
 		}
 	}()

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -64,6 +64,22 @@ func (c *Client) Send(content protocol.Content, mentions []string) error {
 	return err
 }
 
+// SendStatus sends a room.status notification with the given status string.
+// An empty status string means the participant is idle.
+func (c *Client) SendStatus(name, status string) error {
+	params := protocol.StatusParams{
+		Name:   name,
+		Status: status,
+	}
+	notif := protocol.NewNotification("room.status", params)
+	data, err := protocol.EncodeLine(notif)
+	if err != nil {
+		return err
+	}
+	_, err = c.conn.Write(data)
+	return err
+}
+
 // Close signals the read loop to stop and closes the underlying connection.
 // It is safe to call Close concurrently or more than once.
 func (c *Client) Close() error {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -135,6 +135,65 @@ func TestClientSendsAndReceives(t *testing.T) {
 	}
 }
 
+// TestClientSendStatus verifies that sending a room.status notification results
+// in other participants receiving it.
+func TestClientSendStatus(t *testing.T) {
+	srv, err := server.New("127.0.0.1:0", "test-room")
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+	defer srv.Close()
+	go srv.Serve()
+
+	addr := srv.Addr()
+
+	// Connect alice.
+	alice, err := client.New(addr)
+	if err != nil {
+		t.Fatalf("client.New alice: %v", err)
+	}
+	defer alice.Close()
+	if err := alice.Join(protocol.JoinParams{Name: "alice", Role: "human"}); err != nil {
+		t.Fatalf("alice.Join: %v", err)
+	}
+	drain(alice.Incoming(), 1) // consume room.state
+
+	// Connect bot.
+	bot, err := client.New(addr)
+	if err != nil {
+		t.Fatalf("client.New bot: %v", err)
+	}
+	defer bot.Close()
+	if err := bot.Join(protocol.JoinParams{Name: "bot", Role: "agent", AgentType: "claude"}); err != nil {
+		t.Fatalf("bot.Join: %v", err)
+	}
+	drain(bot.Incoming(), 1) // consume room.state
+
+	// Bot sends a status update.
+	if err := bot.SendStatus("bot", "thinking…"); err != nil {
+		t.Fatalf("bot.SendStatus: %v", err)
+	}
+
+	// Alice should receive a room.status notification.
+	msgs := drain(alice.Incoming(), 5) // allow for join notifications too
+	found := false
+	for _, m := range msgs {
+		if m.Method == "room.status" {
+			var params protocol.StatusParams
+			if err := json.Unmarshal(m.Params, &params); err != nil {
+				t.Fatalf("unmarshal room.status params: %v", err)
+			}
+			if params.Name == "bot" && params.Status == "thinking…" {
+				found = true
+				break
+			}
+		}
+	}
+	if !found {
+		t.Errorf("alice did not receive bot's status; got methods: %v", methodsOf(msgs))
+	}
+}
+
 // TestClientConcurrentClose verifies that calling Close() from two goroutines
 // simultaneously does not panic.
 func TestClientConcurrentClose(t *testing.T) {

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -101,6 +101,14 @@ type LeftParams struct {
 	Name string `json:"name"`
 }
 
+// StatusParams is the params payload for a "room.status" notification.
+// Status is a short description of what the participant is doing, e.g.
+// "thinking…", "using: Read", or "" to indicate idle.
+type StatusParams struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+}
+
 // Participant describes a single participant in a room.
 type Participant struct {
 	Name      string `json:"name"`

--- a/internal/protocol/protocol_test.go
+++ b/internal/protocol/protocol_test.go
@@ -142,6 +142,58 @@ func TestParseMentions_ExtractsAtMentions(t *testing.T) {
 	}
 }
 
+func TestStatusParamsEncodeDecodeRoundTrip(t *testing.T) {
+	params := protocol.StatusParams{
+		Name:   "bot1",
+		Status: "thinking…",
+	}
+
+	n := protocol.NewNotification("room.status", params)
+	data, err := protocol.EncodeLine(n)
+	if err != nil {
+		t.Fatalf("EncodeLine error: %v", err)
+	}
+
+	msg, err := protocol.DecodeLine(data)
+	if err != nil {
+		t.Fatalf("DecodeLine error: %v", err)
+	}
+	if msg.Method != "room.status" {
+		t.Errorf("method mismatch: got %q", msg.Method)
+	}
+
+	var decoded protocol.StatusParams
+	if err := json.Unmarshal(msg.Params, &decoded); err != nil {
+		t.Fatalf("Unmarshal StatusParams error: %v", err)
+	}
+	if decoded.Name != "bot1" {
+		t.Errorf("Name mismatch: got %q", decoded.Name)
+	}
+	if decoded.Status != "thinking…" {
+		t.Errorf("Status mismatch: got %q", decoded.Status)
+	}
+}
+
+func TestStatusParamsEmptyStatus(t *testing.T) {
+	params := protocol.StatusParams{Name: "bot1", Status: ""}
+	n := protocol.NewNotification("room.status", params)
+	data, err := protocol.EncodeLine(n)
+	if err != nil {
+		t.Fatalf("EncodeLine error: %v", err)
+	}
+	msg, err := protocol.DecodeLine(data)
+	if err != nil {
+		t.Fatalf("DecodeLine error: %v", err)
+	}
+	var decoded protocol.StatusParams
+	if err := json.Unmarshal(msg.Params, &decoded); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+	if decoded.Status != "" {
+		t.Errorf("expected empty status, got %q", decoded.Status)
+	}
+}
+
 func TestJoinParamsEncodeDecodeRoundTrip(t *testing.T) {
 	params := protocol.JoinParams{
 		Name:      "agent-x",

--- a/internal/server/room.go
+++ b/internal/server/room.go
@@ -144,6 +144,29 @@ func (r *Room) BroadcastJoined(jp protocol.JoinedParams) {
 	}
 }
 
+// BroadcastStatus sends a room.status notification to all participants except
+// the sender (identified by sp.Name).
+func (r *Room) BroadcastStatus(sp protocol.StatusParams) {
+	notif := protocol.NewNotification("room.status", sp)
+	data, _ := protocol.EncodeLine(notif)
+
+	r.mu.RLock()
+	targets := make([]chan []byte, 0, len(r.Participants))
+	for name, cc := range r.Participants {
+		if name != sp.Name {
+			targets = append(targets, cc.Send)
+		}
+	}
+	r.mu.RUnlock()
+
+	for _, ch := range targets {
+		select {
+		case ch <- data:
+		default:
+		}
+	}
+}
+
 // BroadcastLeft sends a room.left notification to all remaining participants.
 func (r *Room) BroadcastLeft(lp protocol.LeftParams) {
 	notif := protocol.NewNotification("room.left", lp)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -155,6 +155,18 @@ func (s *Server) handleConn(conn net.Conn) {
 				continue
 			}
 			s.room.Broadcast(cc.Name, cc.Source, cc.Role, params.Content[0], params.Mentions)
+
+		case "room.status":
+			if cc == nil {
+				continue
+			}
+			var params protocol.StatusParams
+			if err := json.Unmarshal(raw.Params, &params); err != nil {
+				continue
+			}
+			// Override name with the authenticated connection name for safety.
+			params.Name = cc.Name
+			s.room.BroadcastStatus(params)
 		}
 	}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -231,6 +231,79 @@ func TestDuplicateNameRejected(t *testing.T) {
 	}
 }
 
+// TestServerBroadcastsRoomStatus verifies that when one client sends room.status,
+// the other client receives a room.status notification.
+func TestServerBroadcastsRoomStatus(t *testing.T) {
+	s := newTestServer(t)
+
+	// Connect alice
+	connAlice := dialServer(t, s.Addr())
+	scAlice := newScanner(connAlice)
+
+	sendLine(t, connAlice, protocol.NewNotification("room.join", protocol.JoinParams{
+		Name: "alice",
+		Role: "user",
+	}))
+	readLine(t, scAlice) // consume room.state
+
+	// Connect bot1
+	connBot := dialServer(t, s.Addr())
+	scBot := newScanner(connBot)
+
+	sendLine(t, connBot, protocol.NewNotification("room.join", protocol.JoinParams{
+		Name:      "bot1",
+		Role:      "agent",
+		AgentType: "claude",
+	}))
+	readLine(t, scBot) // consume room.state for bot1
+
+	// Give the server time to deliver join notifications to alice.
+	time.Sleep(50 * time.Millisecond)
+
+	// Bot sends room.status
+	sendLine(t, connBot, protocol.NewNotification("room.status", protocol.StatusParams{
+		Name:   "bot1",
+		Status: "thinking…",
+	}))
+
+	// Alice should eventually receive a room.status notification.
+	// She may first receive room.joined and system messages from bot joining.
+	deadline := time.Now().Add(2 * time.Second)
+	var foundStatus *protocol.StatusParams
+	for time.Now().Before(deadline) {
+		connAlice.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+		if !scAlice.Scan() {
+			break
+		}
+		connAlice.SetReadDeadline(time.Time{})
+
+		var raw protocol.RawMessage
+		if err := json.Unmarshal(scAlice.Bytes(), &raw); err != nil {
+			continue
+		}
+		if raw.Method != "room.status" {
+			continue
+		}
+		var sp protocol.StatusParams
+		if err := json.Unmarshal(raw.Params, &sp); err != nil {
+			continue
+		}
+		foundStatus = &sp
+		break
+	}
+	connAlice.SetReadDeadline(time.Time{})
+
+	if foundStatus == nil {
+		t.Fatal("alice never received room.status notification from bot1")
+	}
+	if foundStatus.Name != "bot1" {
+		t.Errorf("expected status Name %q, got %q", "bot1", foundStatus.Name)
+	}
+	if foundStatus.Status != "thinking…" {
+		t.Errorf("expected status %q, got %q", "thinking…", foundStatus.Status)
+	}
+}
+
 // TestRoomLeftBroadcast verifies that when B disconnects, A receives a
 // room.left notification with B's name.
 func TestRoomLeftBroadcast(t *testing.T) {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -22,12 +22,6 @@ type AgentTypingMsg struct {
 	Text string
 }
 
-// AgentStatusMsg carries a status string (e.g. "thinking...", "using tool: ls")
-// to display in the agent input area when no text is being streamed.
-type AgentStatusMsg struct {
-	Status string
-}
-
 // App is the root Bubble Tea model that composes all TUI components.
 type App struct {
 	topbar  TopBar
@@ -97,10 +91,6 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case AgentTypingMsg:
 		a.input.SetAgentText(m.Text)
-		return a, nil
-
-	case AgentStatusMsg:
-		a.input.SetAgentStatus(m.Status)
 		return a, nil
 	}
 
@@ -182,6 +172,12 @@ func (a *App) handleServerMsg(raw *protocol.RawMessage) {
 		var params protocol.LeftParams
 		if err := json.Unmarshal(raw.Params, &params); err == nil {
 			a.sidebar.RemoveParticipant(params.Name)
+		}
+
+	case "room.status":
+		var params protocol.StatusParams
+		if err := json.Unmarshal(raw.Params, &params); err == nil {
+			a.sidebar.SetParticipantStatus(params.Name, params.Status)
 		}
 	}
 }

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -118,6 +118,45 @@ func TestHandleServerMsg_RoomLeft_RemovesParticipant(t *testing.T) {
 	}
 }
 
+func TestHandleServerMsg_RoomStatus_UpdatesSidebarStatus(t *testing.T) {
+	a := makeApp()
+	a.sidebar.SetParticipants([]protocol.Participant{
+		{Name: "bot1", Role: "agent"},
+	})
+
+	sp := protocol.StatusParams{Name: "bot1", Status: "thinking…"}
+	raw := &protocol.RawMessage{
+		Method: "room.status",
+		Params: rawParams(t, sp),
+	}
+
+	a.handleServerMsg(raw)
+
+	if a.sidebar.statuses["bot1"] != "thinking…" {
+		t.Errorf("expected sidebar status 'thinking…' for bot1, got %q", a.sidebar.statuses["bot1"])
+	}
+}
+
+func TestHandleServerMsg_RoomStatusClear_ClearsSidebarStatus(t *testing.T) {
+	a := makeApp()
+	a.sidebar.SetParticipants([]protocol.Participant{
+		{Name: "bot1", Role: "agent"},
+	})
+	a.sidebar.SetParticipantStatus("bot1", "thinking…")
+
+	sp := protocol.StatusParams{Name: "bot1", Status: ""}
+	raw := &protocol.RawMessage{
+		Method: "room.status",
+		Params: rawParams(t, sp),
+	}
+
+	a.handleServerMsg(raw)
+
+	if a.sidebar.statuses["bot1"] != "" {
+		t.Errorf("expected empty status after clear, got %q", a.sidebar.statuses["bot1"])
+	}
+}
+
 func TestHandleServerMsg_NilRaw_NoOp(t *testing.T) {
 	a := makeApp()
 	// Should not panic.

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -21,11 +21,10 @@ const (
 
 // Input is the bottom input component.
 type Input struct {
-	ta          textarea.Model
-	mode        InputMode
-	agentText   string
-	agentStatus string
-	width       int
+	ta        textarea.Model
+	mode      InputMode
+	agentText string
+	width     int
 }
 
 // NewInput creates an Input component in human mode.
@@ -56,18 +55,8 @@ func (i *Input) SetMode(m InputMode) {
 }
 
 // SetAgentText updates the streaming text shown in agent mode.
-// Setting text also clears the status indicator.
 func (i *Input) SetAgentText(text string) {
 	i.agentText = text
-	if text != "" {
-		i.agentStatus = ""
-	}
-}
-
-// SetAgentStatus sets an activity status message (e.g. "thinking...",
-// "using tool: Read"). Takes priority over streaming text.
-func (i *Input) SetAgentStatus(status string) {
-	i.agentStatus = status
 }
 
 // Value returns the current textarea content (human mode only).
@@ -107,15 +96,10 @@ func (i Input) View() string {
 	cw := i.contentWidth()
 	switch i.mode {
 	case InputModeAgent:
-		if i.agentStatus != "" {
-			// Status (thinking, tool use) takes priority — shows what agent is doing
-			content = systemMsgStyle.Width(cw).Render(i.agentStatus)
-		} else if i.agentText != "" {
-			// Wrap the streaming text to the content width, then show the last
-			// visible line(s) with a blinking cursor indicator at the end.
+		if i.agentText != "" {
+			// Wrap the streaming text to the content width, then show the last line
 			wrapped := lipgloss.NewStyle().Width(cw).Render(i.agentText)
 			lines := strings.Split(wrapped, "\n")
-			// Keep only the last line for the single-row input display.
 			lastLine := lines[len(lines)-1]
 			content = lipgloss.NewStyle().Foreground(colorAgent).Render(lastLine) +
 				systemMsgStyle.Render(" ▊")

--- a/internal/tui/input_test.go
+++ b/internal/tui/input_test.go
@@ -22,23 +22,7 @@ func TestInputAgentMode_EmptyShowsWaiting(t *testing.T) {
 
 // TestInputAgentMode_StatusTakesPriority verifies that a status message is shown
 // when both agentStatus and agentText are set.
-func TestInputAgentMode_StatusTakesPriority(t *testing.T) {
-	inp := NewInput()
-	inp.SetMode(InputModeAgent)
-	inp.SetWidth(80)
-	inp.SetAgentText("some streaming text")
-	inp.SetAgentStatus("thinking...")
-
-	view := inp.View()
-	plain := stripANSI(view)
-
-	if !strings.Contains(plain, "thinking...") {
-		t.Errorf("expected status 'thinking...' in view, got:\n%s", plain)
-	}
-	if strings.Contains(plain, "some streaming text") {
-		t.Errorf("streaming text should NOT appear when status is set, got:\n%s", plain)
-	}
-}
+// Status display moved to sidebar (issue #4) — no status tests in input
 
 // TestInputAgentMode_LongTextWraps verifies that text longer than the input
 // width is wrapped so that no rendered line exceeds the total width.
@@ -104,22 +88,4 @@ func TestInputHumanMode_PlaceholderVisible(t *testing.T) {
 	}
 }
 
-// TestInputAgentMode_SetAgentTextClearsStatus verifies that calling SetAgentText
-// with a non-empty value clears the status.
-func TestInputAgentMode_SetAgentTextClearsStatus(t *testing.T) {
-	inp := NewInput()
-	inp.SetMode(InputModeAgent)
-	inp.SetWidth(80)
-	inp.SetAgentStatus("thinking...")
-	inp.SetAgentText("new text")
-
-	view := inp.View()
-	plain := stripANSI(view)
-
-	if strings.Contains(plain, "thinking...") {
-		t.Errorf("status should be cleared after SetAgentText with text, got:\n%s", plain)
-	}
-	if !strings.Contains(plain, "new text") {
-		t.Errorf("expected 'new text' in view, got:\n%s", plain)
-	}
-}
+// SetAgentTextClearsStatus test removed — status moved to sidebar (issue #4)

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -10,13 +10,14 @@ import (
 // Sidebar renders the participant list panel.
 type Sidebar struct {
 	participants []protocol.Participant
+	statuses     map[string]string // per-participant status text
 	width        int
 	height       int
 }
 
 // NewSidebar creates an empty Sidebar.
 func NewSidebar() Sidebar {
-	return Sidebar{}
+	return Sidebar{statuses: make(map[string]string)}
 }
 
 // SetSize updates the sidebar dimensions.
@@ -40,6 +41,15 @@ func (s *Sidebar) AddParticipant(p protocol.Participant) {
 		}
 	}
 	s.participants = append(s.participants, p)
+}
+
+// SetParticipantStatus updates the activity status for a named participant.
+// An empty status string means the participant is idle (nothing is shown).
+func (s *Sidebar) SetParticipantStatus(name, status string) {
+	if s.statuses == nil {
+		s.statuses = make(map[string]string)
+	}
+	s.statuses[name] = status
 }
 
 // RemoveParticipant removes a participant by name.
@@ -76,6 +86,11 @@ func (s Sidebar) View() string {
 			nameLine = lipgloss.JoinHorizontal(lipgloss.Top, nameLine, " ", badge)
 		}
 		lines = append(lines, nameLine)
+
+		// Show per-participant status when non-empty.
+		if status := s.statuses[p.Name]; status != "" {
+			lines = append(lines, participantStatusStyle.Render("  "+status))
+		}
 
 		if p.AgentType != "" {
 			lines = append(lines, systemMsgStyle.Render("  "+p.AgentType))

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -106,6 +106,58 @@ func TestSidebarViewSmallWidth(t *testing.T) {
 	_ = s.View()
 }
 
+func TestSidebarSetParticipantStatus(t *testing.T) {
+	s := NewSidebar()
+	s.AddParticipant(protocol.Participant{Name: "alice", Role: "human"})
+	s.AddParticipant(protocol.Participant{Name: "bot1", Role: "coder"})
+
+	s.SetParticipantStatus("bot1", "thinking…")
+
+	if s.statuses["bot1"] != "thinking…" {
+		t.Errorf("expected status 'thinking…' for bot1, got %q", s.statuses["bot1"])
+	}
+	// Alice's status should be unaffected
+	if s.statuses["alice"] != "" {
+		t.Errorf("expected empty status for alice, got %q", s.statuses["alice"])
+	}
+}
+
+func TestSidebarSetParticipantStatusClear(t *testing.T) {
+	s := NewSidebar()
+	s.AddParticipant(protocol.Participant{Name: "bot1", Role: "coder"})
+	s.SetParticipantStatus("bot1", "thinking…")
+	s.SetParticipantStatus("bot1", "")
+
+	if s.statuses["bot1"] != "" {
+		t.Errorf("expected empty status after clear, got %q", s.statuses["bot1"])
+	}
+}
+
+func TestSidebarViewShowsStatus(t *testing.T) {
+	s := NewSidebar()
+	s.SetSize(30, 20)
+	s.AddParticipant(protocol.Participant{Name: "bot1", Role: "coder", Source: "agent"})
+	s.SetParticipantStatus("bot1", "thinking…")
+
+	view := s.View()
+	if !contains(view, "thinking…") {
+		t.Errorf("sidebar view should contain status 'thinking…', got: %q", view)
+	}
+}
+
+func TestSidebarViewNoStatusForIdle(t *testing.T) {
+	s := NewSidebar()
+	s.SetSize(30, 20)
+	s.AddParticipant(protocol.Participant{Name: "bot1", Role: "coder", Source: "agent"})
+	// No status set — idle
+
+	view := s.View()
+	// Should not contain any status indicator
+	if contains(view, "thinking") || contains(view, "using") {
+		t.Errorf("sidebar view should not show status for idle participant, got: %q", view)
+	}
+}
+
 func TestSidebarViewContainsNames(t *testing.T) {
 	s := NewSidebar()
 	s.SetSize(30, 20)

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -57,4 +57,8 @@ var (
 
 	timestampStyle = lipgloss.NewStyle().
 			Foreground(colorDimText)
+
+	participantStatusStyle = lipgloss.NewStyle().
+				Foreground(colorSystem).
+				Italic(true)
 )


### PR DESCRIPTION
Fixes #4. Agent activity (thinking, tool use) now shown in sidebar per participant instead of input box. Adds room.status protocol notification.