### PR TITLE
feat: response declaration protocol — [LISTENING] signal

### DIFF
--- a/cmd/parley/main.go
+++ b/cmd/parley/main.go
@@ -272,13 +272,15 @@ func runJoin(cmd *cobra.Command, args []string) error {
 				_ = c.SendStatus(joinName, status)
 			case driver.EventDone:
 				text := strings.TrimSpace(accumulated.String())
-				if text != "" {
+				if driver.IsListeningSignal(text) {
+					_ = c.SendStatus(joinName, "listening")
+				} else if text != "" {
 					mentions := protocol.ParseMentions(text)
 					_ = c.Send(protocol.Content{Type: "text", Text: text}, mentions)
+					_ = c.SendStatus(joinName, "")
 				}
 				accumulated.Reset()
 				p.Send(tui.AgentTypingMsg{Text: ""})
-				_ = c.SendStatus(joinName, "")
 			}
 		}
 	}()

--- a/internal/driver/claude.go
+++ b/internal/driver/claude.go
@@ -307,10 +307,23 @@ func BuildSystemPrompt(config AgentConfig) string {
 - If unsure whether to respond, default to staying silent
 - Keep responses focused and concise — this is a chat, not a monologue
 - You can @-mention other participants to ask them questions
+- If you decide not to respond to a message, output exactly [LISTENING] on a line by itself and nothing else
 
 When you respond, just write your message directly. Do not prefix it with your name.`)
 
 	return sb.String()
+}
+
+// ---------------------------------------------------------------------------
+// IsListeningSignal
+// ---------------------------------------------------------------------------
+
+// IsListeningSignal reports whether the agent's accumulated response text
+// should be treated as a silence signal rather than a chat message.
+// An agent outputs exactly "[LISTENING]" (on its own, possibly surrounded by
+// whitespace) when it decides not to respond to a message.
+func IsListeningSignal(text string) bool {
+	return strings.TrimSpace(text) == "[LISTENING]"
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/driver/driver_test.go
+++ b/internal/driver/driver_test.go
@@ -490,6 +490,66 @@ func TestReadLoop_DefaultBufferFailsOnLargeLine(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// TestBuildSystemPrompt_ContainsListeningInstruction
+// ---------------------------------------------------------------------------
+
+func TestBuildSystemPrompt_ContainsListeningInstruction(t *testing.T) {
+	cfg := AgentConfig{
+		Name:      "Alice",
+		Role:      "engineer",
+		Directory: "/tmp",
+		Topic:     "topic",
+		Participants: []ParticipantInfo{
+			{Name: "Alice", Role: "engineer", Directory: "/tmp"},
+		},
+	}
+	prompt := BuildSystemPrompt(cfg)
+	if !strings.Contains(prompt, "[LISTENING]") {
+		t.Errorf("expected system prompt to contain '[LISTENING]' instruction, got:\n%s", prompt)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestIsListeningSignal
+// ---------------------------------------------------------------------------
+
+func TestIsListeningSignal_ExactMatch(t *testing.T) {
+	if !IsListeningSignal("[LISTENING]") {
+		t.Error("expected IsListeningSignal to return true for '[LISTENING]'")
+	}
+}
+
+func TestIsListeningSignal_WithWhitespace(t *testing.T) {
+	cases := []string{
+		"  [LISTENING]  ",
+		"\n[LISTENING]\n",
+		"\t[LISTENING]\t",
+		"[LISTENING]\n",
+	}
+	for _, c := range cases {
+		if !IsListeningSignal(c) {
+			t.Errorf("expected IsListeningSignal(%q) to return true", c)
+		}
+	}
+}
+
+func TestIsListeningSignal_FalseForOtherText(t *testing.T) {
+	cases := []string{
+		"",
+		"Hello world",
+		"I am [LISTENING] to you",
+		"[listening]",
+		"LISTENING",
+	}
+	for _, c := range cases {
+		if IsListeningSignal(c) {
+			t.Errorf("expected IsListeningSignal(%q) to return false", c)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
 // TestReadLoop_OneMBBufferHandlesLargeLine verifies that readLoop with a 1 MB
 // buffer correctly processes a >64 KB NDJSON line and emits an EventDone.
 func TestReadLoop_OneMBBufferHandlesLargeLine(t *testing.T) {

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -89,7 +89,11 @@ func (s Sidebar) View() string {
 
 		// Show per-participant status when non-empty.
 		if status := s.statuses[p.Name]; status != "" {
-			lines = append(lines, participantStatusStyle.Render("  "+status))
+			if status == "listening" {
+				lines = append(lines, listeningStatusStyle.Render("  👂 listening"))
+			} else {
+				lines = append(lines, participantStatusStyle.Render("  "+status))
+			}
 		}
 
 		if p.AgentType != "" {

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -145,6 +145,18 @@ func TestSidebarViewShowsStatus(t *testing.T) {
 	}
 }
 
+func TestSidebarViewListeningStatus(t *testing.T) {
+	s := NewSidebar()
+	s.SetSize(30, 20)
+	s.AddParticipant(protocol.Participant{Name: "bot1", Role: "coder", Source: "agent"})
+	s.SetParticipantStatus("bot1", "listening")
+
+	view := s.View()
+	if !contains(view, "listening") {
+		t.Errorf("sidebar view should contain 'listening' status, got: %q", view)
+	}
+}
+
 func TestSidebarViewNoStatusForIdle(t *testing.T) {
 	s := NewSidebar()
 	s.SetSize(30, 20)

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -61,4 +61,8 @@ var (
 	participantStatusStyle = lipgloss.NewStyle().
 				Foreground(colorSystem).
 				Italic(true)
+
+	listeningStatusStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#3fb950")).
+				Italic(true)
 )


### PR DESCRIPTION
## Summary

- Adds `[LISTENING]` instruction to `BuildSystemPrompt()` so agents know to output this token when choosing silence
- Adds `IsListeningSignal(text string) bool` helper in `internal/driver/claude.go` to detect the token
- Updates the agent→network bridge in `cmd/parley/main.go`: on `EventDone`, if the response is `[LISTENING]`, sends `c.SendStatus(name, "listening")` instead of a chat message; clears status after a real message
- Sidebar renders `"listening"` status with a 👂 emoji and muted green color via a new `listeningStatusStyle`

## Test plan

- [x] `TestBuildSystemPrompt_ContainsListeningInstruction` — system prompt contains the `[LISTENING]` guideline
- [x] `TestIsListeningSignal_ExactMatch` — `[LISTENING]` returns true
- [x] `TestIsListeningSignal_WithWhitespace` — whitespace-padded variants return true
- [x] `TestIsListeningSignal_FalseForOtherText` — non-signal text returns false
- [x] `TestSidebarViewListeningStatus` — sidebar renders "listening" status text
- [x] `go test ./... -timeout 30s -race` — full suite passes

Fixes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)