### PR TITLE
feat: debounce agent responses when not @-mentioned

### DIFF
--- a/cmd/parley/main.go
+++ b/cmd/parley/main.go
@@ -238,6 +238,17 @@ func runJoin(cmd *cobra.Command, args []string) error {
 
 	// Bridge network → TUI + agent driver.
 	go func() {
+		var pendingMsg string
+		var pendingTimer *time.Timer
+
+		flushPending := func() {
+			if pendingMsg != "" {
+				_ = d.Send(pendingMsg)
+				pendingMsg = ""
+			}
+			pendingTimer = nil
+		}
+
 		for msg := range c.Incoming() {
 			p.Send(tui.ServerMsg{Raw: msg})
 
@@ -245,13 +256,42 @@ func runJoin(cmd *cobra.Command, args []string) error {
 				var params protocol.MessageParams
 				if err := json.Unmarshal(msg.Params, &params); err == nil {
 					if params.From != joinName {
-						// Format message and send to agent driver.
-						text := fmt.Sprintf("%s: %s", params.From, contentText(params.Content))
-						_ = d.Send(text)
+						// Format message and decide whether to delay.
+						formatted := fmt.Sprintf("%s: %s", params.From, contentText(params.Content))
+						if isMentioned(params.Mentions, joinName) {
+							// @-mentioned: flush any pending messages and send immediately.
+							if pendingTimer != nil {
+								pendingTimer.Stop()
+								pendingTimer = nil
+							}
+							if pendingMsg != "" {
+								_ = d.Send(pendingMsg)
+								pendingMsg = ""
+							}
+							_ = d.Send(formatted)
+						} else {
+							// Not mentioned: batch with a 2-second debounce timer.
+							if pendingMsg != "" {
+								pendingMsg += "\n" + formatted
+							} else {
+								pendingMsg = formatted
+							}
+							if pendingTimer == nil {
+								pendingTimer = time.AfterFunc(2*time.Second, flushPending)
+							} else {
+								pendingTimer.Reset(2 * time.Second)
+							}
+						}
 					}
 				}
 			}
 		}
+
+		// Flush any remaining pending message when the channel closes.
+		if pendingTimer != nil {
+			pendingTimer.Stop()
+		}
+		flushPending()
 	}()
 
 	// Bridge agent → network.
@@ -287,6 +327,16 @@ func runJoin(cmd *cobra.Command, args []string) error {
 
 	_, err = p.Run()
 	return err
+}
+
+// isMentioned reports whether name appears in the mentions list.
+func isMentioned(mentions []string, name string) bool {
+	for _, m := range mentions {
+		if m == name {
+			return true
+		}
+	}
+	return false
 }
 
 // contentText extracts the text from a slice of Content items.

--- a/cmd/parley/main_test.go
+++ b/cmd/parley/main_test.go
@@ -1,0 +1,58 @@
+package main
+
+import "testing"
+
+func TestIsMentioned(t *testing.T) {
+	tests := []struct {
+		name     string
+		mentions []string
+		agent    string
+		want     bool
+	}{
+		{
+			name:     "mentioned",
+			mentions: []string{"alice", "bob"},
+			agent:    "bob",
+			want:     true,
+		},
+		{
+			name:     "not mentioned",
+			mentions: []string{"alice", "charlie"},
+			agent:    "bob",
+			want:     false,
+		},
+		{
+			name:     "empty mentions",
+			mentions: []string{},
+			agent:    "bob",
+			want:     false,
+		},
+		{
+			name:     "nil mentions",
+			mentions: nil,
+			agent:    "bob",
+			want:     false,
+		},
+		{
+			name:     "exact match required",
+			mentions: []string{"bobby"},
+			agent:    "bob",
+			want:     false,
+		},
+		{
+			name:     "single match",
+			mentions: []string{"bob"},
+			agent:    "bob",
+			want:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isMentioned(tt.mentions, tt.agent)
+			if got != tt.want {
+				t.Errorf("isMentioned(%v, %q) = %v, want %v", tt.mentions, tt.agent, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a 2-second debounce delay before forwarding un-mentioned messages to the agent driver, preventing all agents from piling on simultaneously
- @-mentioned messages are forwarded immediately and flush any in-flight pending batch
- Batches multiple un-mentioned messages that arrive within the debounce window into a single forwarded message
- Adds `isMentioned(mentions []string, name string) bool` helper with 6 unit tests in `cmd/parley/main_test.go`

Fixes #16

## Test plan
- [x] `go test ./... -timeout 30s -race` — all packages pass
- [ ] Manual: start a session with 2+ agents, send a general (non-@) message — agents should not respond simultaneously
- [ ] Manual: send `@agentName some task` — that agent responds immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)