### PR TITLE
feat: driver auto-detection via registry (Fixes #20)

### DIFF
--- a/cmd/parley/main.go
+++ b/cmd/parley/main.go
@@ -227,7 +227,10 @@ func runJoin(cmd *cobra.Command, args []string) error {
 	config.SystemPrompt = driver.BuildSystemPrompt(config)
 
 	ctx := context.Background()
-	d := &driver.ClaudeDriver{}
+	d, err := driver.NewDriver(command)
+	if err != nil {
+		return fmt.Errorf("join: %w", err)
+	}
 	if err := d.Start(ctx, config); err != nil {
 		return fmt.Errorf("join: start agent driver: %w", err)
 	}

--- a/internal/driver/registry.go
+++ b/internal/driver/registry.go
@@ -1,0 +1,18 @@
+package driver
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// NewDriver creates the appropriate AgentDriver for the given command name.
+// Use filepath.Base so paths like /usr/bin/claude still match.
+func NewDriver(command string) (AgentDriver, error) {
+	switch strings.ToLower(filepath.Base(command)) {
+	case "claude":
+		return &ClaudeDriver{}, nil
+	default:
+		return nil, fmt.Errorf("unsupported agent command: %q (supported: claude)", command)
+	}
+}

--- a/internal/driver/registry_test.go
+++ b/internal/driver/registry_test.go
@@ -1,0 +1,40 @@
+package driver
+
+import (
+	"testing"
+)
+
+func TestNewDriver_Claude(t *testing.T) {
+	d, err := NewDriver("claude")
+	if err != nil {
+		t.Fatalf("NewDriver(%q) returned error: %v", "claude", err)
+	}
+	if _, ok := d.(*ClaudeDriver); !ok {
+		t.Errorf("NewDriver(%q) returned %T, want *ClaudeDriver", "claude", d)
+	}
+}
+
+func TestNewDriver_GeminiNotYetSupported(t *testing.T) {
+	// Gemini driver is not yet implemented; NewDriver should return an error.
+	_, err := NewDriver("gemini")
+	if err == nil {
+		t.Error("NewDriver(\"gemini\") expected error (not yet implemented), got nil")
+	}
+}
+
+func TestNewDriver_PathHandling(t *testing.T) {
+	d, err := NewDriver("/usr/bin/claude")
+	if err != nil {
+		t.Fatalf("NewDriver(%q) returned error: %v", "/usr/bin/claude", err)
+	}
+	if _, ok := d.(*ClaudeDriver); !ok {
+		t.Errorf("NewDriver(%q) returned %T, want *ClaudeDriver", "/usr/bin/claude", d)
+	}
+}
+
+func TestNewDriver_Unknown(t *testing.T) {
+	_, err := NewDriver("unknown")
+	if err == nil {
+		t.Error("NewDriver(\"unknown\") expected error, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `NewDriver(command string) (AgentDriver, error)` in `internal/driver/registry.go` that selects the driver using `filepath.Base` so paths like `/usr/bin/claude` match correctly
- Currently supports `claude`; returns an error for unsupported commands including `gemini` (pending issue #19)
- Update `runJoin()` in `cmd/parley/main.go` to call `NewDriver` instead of hardcoding `&driver.ClaudeDriver{}`

## Test plan
- [x] `TestNewDriver_Claude` — "claude" returns `*ClaudeDriver`
- [x] `TestNewDriver_PathHandling` — "/usr/bin/claude" returns `*ClaudeDriver`
- [x] `TestNewDriver_GeminiNotYetSupported` — "gemini" returns error (driver not yet implemented)
- [x] `TestNewDriver_Unknown` — "unknown" returns error
- [x] Full suite `go test ./... -timeout 30s -race` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)