### PR TITLE
feat: stable room IDs using UUID v4

### DIFF
--- a/cmd/parley/main.go
+++ b/cmd/parley/main.go
@@ -89,10 +89,11 @@ func runHost(cmd *cobra.Command, args []string) error {
 	go srv.Serve()
 
 	port := srv.Port()
+	roomID := srv.Room().ID
 	fmt.Fprintf(os.Stderr, "Parley server listening on port %d\n", port)
+	fmt.Fprintf(os.Stderr, "Room ID: %s\n", roomID)
 
 	defer func() {
-		roomID := fmt.Sprintf("%d", srv.Port())
 		dir := server.RoomDir(roomID)
 		if err := server.SaveRoom(dir, srv.Room()); err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to save room: %v\n", err)

--- a/internal/server/persistence.go
+++ b/internal/server/persistence.go
@@ -45,7 +45,7 @@ func SaveRoom(dir string, room *Room) error {
 	// Write room.json.
 	rd := RoomData{
 		Topic: room.Topic,
-		ID:    dir,
+		ID:    room.ID,
 	}
 	if err := writeJSON(filepath.Join(dir, "room.json"), rd); err != nil {
 		return fmt.Errorf("write room.json: %w", err)
@@ -87,6 +87,7 @@ func LoadRoom(dir string) (*Room, error) {
 	}
 
 	room := NewRoom(rd.Topic)
+	room.ID = rd.ID
 
 	var msgs []protocol.MessageParams
 	if err := readJSON(filepath.Join(dir, "messages.json"), &msgs); err != nil {

--- a/internal/server/persistence_test.go
+++ b/internal/server/persistence_test.go
@@ -88,3 +88,45 @@ func TestRoomDir(t *testing.T) {
 		t.Errorf("expected path to end with /rooms/abc123, got %q", dir)
 	}
 }
+
+func TestSaveLoadRoomPreservesID(t *testing.T) {
+	dir := t.TempDir()
+
+	room := NewRoom("id-topic")
+	originalID := room.ID
+	if originalID == "" {
+		t.Fatal("NewRoom() must set a non-empty ID before this test is meaningful")
+	}
+
+	if err := SaveRoom(dir, room); err != nil {
+		t.Fatalf("SaveRoom: %v", err)
+	}
+
+	loaded, err := LoadRoom(dir)
+	if err != nil {
+		t.Fatalf("LoadRoom: %v", err)
+	}
+
+	if loaded.ID != originalID {
+		t.Errorf("LoadRoom restored ID %q, want %q", loaded.ID, originalID)
+	}
+}
+
+func TestSaveRoomUsesRoomID(t *testing.T) {
+	dir := t.TempDir()
+	room := NewRoom("topic")
+
+	if err := SaveRoom(dir, room); err != nil {
+		t.Fatalf("SaveRoom: %v", err)
+	}
+
+	// Read the saved room.json and verify the id field matches room.ID.
+	var rd RoomData
+	if err := readJSON(filepath.Join(dir, "room.json"), &rd); err != nil {
+		t.Fatalf("readJSON: %v", err)
+	}
+
+	if rd.ID != room.ID {
+		t.Errorf("room.json ID = %q, want room.ID = %q", rd.ID, room.ID)
+	}
+}

--- a/internal/server/room.go
+++ b/internal/server/room.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"crypto/rand"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -11,6 +12,7 @@ import (
 
 // Room holds the shared state for a single chat room.
 type Room struct {
+	ID           string
 	Topic        string
 	Participants map[string]*ClientConn
 	Messages     []protocol.MessageParams
@@ -30,12 +32,22 @@ type ClientConn struct {
 	Done      chan struct{}
 }
 
-// NewRoom creates a new Room with the given topic.
+// NewRoom creates a new Room with the given topic and a fresh UUID as its ID.
 func NewRoom(topic string) *Room {
 	return &Room{
+		ID:           newUUID(),
 		Topic:        topic,
 		Participants: make(map[string]*ClientConn),
 	}
+}
+
+// newUUID generates a random UUID v4.
+func newUUID() string {
+	b := make([]byte, 16)
+	rand.Read(b)
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
 }
 
 // Join adds cc to the room and returns a snapshot of the current room state,

--- a/internal/server/uuid_test.go
+++ b/internal/server/uuid_test.go
@@ -1,0 +1,47 @@
+package server
+
+import (
+	"regexp"
+	"testing"
+)
+
+var uuidRE = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+
+func TestNewUUIDFormat(t *testing.T) {
+	id := newUUID()
+	if !uuidRE.MatchString(id) {
+		t.Errorf("newUUID() = %q, does not match UUID v4 format", id)
+	}
+}
+
+func TestNewUUIDNoDuplicates(t *testing.T) {
+	seen := make(map[string]bool, 1000)
+	for i := 0; i < 1000; i++ {
+		id := newUUID()
+		if seen[id] {
+			t.Fatalf("newUUID() produced a duplicate after %d calls: %q", i, id)
+		}
+		seen[id] = true
+	}
+}
+
+func TestNewRoomSetsID(t *testing.T) {
+	room := NewRoom("test-topic")
+	if room.ID == "" {
+		t.Error("NewRoom() did not set a non-empty ID")
+	}
+	if !uuidRE.MatchString(room.ID) {
+		t.Errorf("NewRoom().ID = %q, does not match UUID v4 format", room.ID)
+	}
+}
+
+func TestNewRoomIDsAreUnique(t *testing.T) {
+	ids := make(map[string]bool, 100)
+	for i := 0; i < 100; i++ {
+		room := NewRoom("topic")
+		if ids[room.ID] {
+			t.Fatalf("NewRoom() produced a duplicate ID: %q", room.ID)
+		}
+		ids[room.ID] = true
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `ID string` field to `Room` struct, generated as a UUID v4 on `NewRoom()`
- `newUUID()` uses `crypto/rand` (no external dependency) to produce compliant v4 UUIDs
- `SaveRoom` now stores `room.ID` in `room.json`; `LoadRoom` restores it
- `runHost` uses `srv.Room().ID` instead of the port number as the persistence directory name, and prints the room ID on startup

Fixes #21

## Test plan

- [x] `TestNewUUIDFormat` — output matches `[0-9a-f]{8}-...-4xxx-[89ab]xxx-...`
- [x] `TestNewUUIDNoDuplicates` — 1000 calls produce no duplicates
- [x] `TestNewRoomSetsID` — `NewRoom()` sets a non-empty, valid UUID v4
- [x] `TestNewRoomIDsAreUnique` — 100 rooms have distinct IDs
- [x] `TestSaveLoadRoomPreservesID` — `LoadRoom` restores the original UUID
- [x] `TestSaveRoomUsesRoomID` — `room.json` `id` field matches `room.ID`
- [x] Full suite `go test ./... -race` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)