### PR TITLE
refactor: unify participants data

### DIFF
--- a/cmd/parley/main.go
+++ b/cmd/parley/main.go
@@ -522,7 +522,7 @@ func (a *RoomAdapter) GetTopic() string     { return a.room.Topic }
 func (a *RoomAdapter) GetPort() int         { return a.port }
 func (a *RoomAdapter) GetMessageCount() int { return a.room.MessageCount() }
 
-func (a *RoomAdapter) GetParticipantSnapshot() []command.ParticipantInfo {
+func (a *RoomAdapter) GetParticipants() []command.ParticipantInfo {
 	conns := a.room.GetParticipants()
 	out := make([]command.ParticipantInfo, len(conns))
 	for i, cc := range conns {
@@ -531,25 +531,8 @@ func (a *RoomAdapter) GetParticipantSnapshot() []command.ParticipantInfo {
 			Role:      cc.Role,
 			Directory: cc.Directory,
 			AgentType: cc.AgentType,
+			Online:    cc.Online,
 		}
-	}
-	return out
-}
-
-func (a *RoomAdapter) GetSavedAgents() []command.SavedAgentInfo {
-	saved := a.room.SavedAgents
-	out := make([]command.SavedAgentInfo, 0, len(saved))
-	for _, sa := range saved {
-		// Only include non-human agents (humans don't resume).
-		if sa.Source == "human" {
-			continue
-		}
-		out = append(out, command.SavedAgentInfo{
-			Name:      sa.Name,
-			Role:      sa.Role,
-			Directory: sa.Directory,
-			AgentType: sa.AgentType,
-		})
 	}
 	return out
 }

--- a/internal/command/cmd_info.go
+++ b/internal/command/cmd_info.go
@@ -9,7 +9,7 @@ var InfoCommand = &Command{
 	Description: "Display current room information",
 	Execute: func(ctx Context, _ string) Result {
 		room := ctx.Room
-		participants := room.GetParticipantSnapshot()
+		participants := room.GetParticipants()
 		port := room.GetPort()
 
 		info := fmt.Sprintf("Room: %s\nTopic: %s\nPort: %d\nParticipants: %d\nMessages: %d\n",
@@ -21,31 +21,28 @@ var InfoCommand = &Command{
 		)
 
 		if len(participants) > 0 {
-			info += "\nConnected:\n"
+			info += "\nParticipants:\n"
 			for _, p := range participants {
-				line := fmt.Sprintf("  • %s (%s)", p.Name, p.Role)
+				status := "online"
+				if !p.Online {
+					status = "offline"
+				}
+				line := fmt.Sprintf("  • %s (%s) [%s]", p.Name, p.Role, status)
 				if p.Directory != "" {
 					line += fmt.Sprintf(" — %s", p.Directory)
 				}
 				info += line + "\n"
+
+				// Show resume hint for offline agents.
+				if !p.Online && p.AgentType != "" {
+					agentCmd := p.AgentType
+					info += fmt.Sprintf("      resume: parley join --port %d --name %s --resume -- %s\n", port, p.Name, agentCmd)
+				}
 			}
 		}
 
 		// Ready-to-copy join command.
 		info += fmt.Sprintf("\nJoin command:\n  parley join --port %d -- claude\n", port)
-
-		// If there are saved agents from prior sessions, show resume commands.
-		savedAgents := room.GetSavedAgents()
-		if len(savedAgents) > 0 {
-			info += "\nResume prior agents:\n"
-			for _, sa := range savedAgents {
-				agentCmd := sa.AgentType
-				if agentCmd == "" {
-					agentCmd = "claude"
-				}
-				info += fmt.Sprintf("  parley join --port %d --name %s --resume -- %s\n", port, sa.Name, agentCmd)
-			}
-		}
 
 		return Result{LocalMessage: info}
 	},

--- a/internal/command/cmd_send_command.go
+++ b/internal/command/cmd_send_command.go
@@ -29,7 +29,7 @@ var SendCommandCommand = &Command{
 
 		// Validate agent exists.
 		found := false
-		for _, p := range ctx.Room.GetParticipantSnapshot() {
+		for _, p := range ctx.Room.GetParticipants() {
 			if p.Name == agentName {
 				found = true
 				break

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -9,9 +9,8 @@ type RoomQuerier interface {
 	GetID() string
 	GetTopic() string
 	GetPort() int
-	GetParticipantSnapshot() []ParticipantInfo
+	GetParticipants() []ParticipantInfo
 	GetMessageCount() int
-	GetSavedAgents() []SavedAgentInfo
 }
 
 // ParticipantInfo is a simplified view of a room participant for command output.
@@ -20,14 +19,7 @@ type ParticipantInfo struct {
 	Role      string
 	Directory string
 	AgentType string
-}
-
-// SavedAgentInfo describes an agent from a prior session that can be resumed.
-type SavedAgentInfo struct {
-	Name      string
-	Role      string
-	Directory string
-	AgentType string // the command used to run the agent (e.g. "claude")
+	Online    bool
 }
 
 // Context carries everything a command needs to execute.

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -13,15 +13,13 @@ type mockRoom struct {
 	port         int
 	participants []ParticipantInfo
 	messageCount int
-	savedAgents  []SavedAgentInfo
 }
 
-func (m *mockRoom) GetID() string                             { return m.id }
-func (m *mockRoom) GetTopic() string                          { return m.topic }
-func (m *mockRoom) GetPort() int                              { return m.port }
-func (m *mockRoom) GetParticipantSnapshot() []ParticipantInfo { return m.participants }
-func (m *mockRoom) GetMessageCount() int                      { return m.messageCount }
-func (m *mockRoom) GetSavedAgents() []SavedAgentInfo          { return m.savedAgents }
+func (m *mockRoom) GetID() string                      { return m.id }
+func (m *mockRoom) GetTopic() string                   { return m.topic }
+func (m *mockRoom) GetPort() int                       { return m.port }
+func (m *mockRoom) GetParticipants() []ParticipantInfo { return m.participants }
+func (m *mockRoom) GetMessageCount() int               { return m.messageCount }
 
 func newTestRoom() *mockRoom {
 	return &mockRoom{
@@ -29,14 +27,12 @@ func newTestRoom() *mockRoom {
 		topic: "test-topic",
 		port:  9000,
 		participants: []ParticipantInfo{
-			{Name: "host-user", Role: "human", Directory: "/home/user"},
-			{Name: "atlas", Role: "agent", Directory: "/tmp/atlas", AgentType: "claude"},
+			{Name: "host-user", Role: "human", Directory: "/home/user", Online: true},
+			{Name: "atlas", Role: "agent", Directory: "/tmp/atlas", AgentType: "claude", Online: true},
+			{Name: "nova", Role: "agent", Directory: "/tmp/nova", AgentType: "claude", Online: false},
+			{Name: "echo", Role: "coder", Directory: "/tmp/echo", AgentType: "gemini", Online: false},
 		},
 		messageCount: 42,
-		savedAgents: []SavedAgentInfo{
-			{Name: "nova", Role: "agent", Directory: "/tmp/nova", AgentType: "claude"},
-			{Name: "echo", Role: "coder", Directory: "/tmp/echo", AgentType: "gemini"},
-		},
 	}
 }
 
@@ -117,11 +113,11 @@ func TestInfoCommand(t *testing.T) {
 	if !strings.Contains(msg, "parley join --port 9000 -- claude") {
 		t.Errorf("info output should contain join command, got:\n%s", msg)
 	}
-	// Should contain resume commands for saved agents.
-	if !strings.Contains(msg, "parley join --port 9000 --name nova --resume -- claude") {
+	// Should contain resume commands for offline agents.
+	if !strings.Contains(msg, "resume: parley join --port 9000 --name nova --resume -- claude") {
 		t.Errorf("info output should contain resume command for nova, got:\n%s", msg)
 	}
-	if !strings.Contains(msg, "parley join --port 9000 --name echo --resume -- gemini") {
+	if !strings.Contains(msg, "resume: parley join --port 9000 --name echo --resume -- gemini") {
 		t.Errorf("info output should contain resume command for echo, got:\n%s", msg)
 	}
 }

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -117,6 +117,7 @@ type Participant struct {
 	Repo      string `json:"repo,omitempty"`
 	AgentType string `json:"agent_type,omitempty"`
 	Source    string `json:"source,omitempty"`
+	Online    bool   `json:"online"`
 }
 
 // RoomStateParams is the params payload for a "room/state" notification.

--- a/internal/server/persistence.go
+++ b/internal/server/persistence.go
@@ -60,8 +60,8 @@ func SaveRoom(dir string, room *Room) error {
 		return fmt.Errorf("write messages.json: %w", err)
 	}
 
-	// Write agents.json (participants snapshot), preserving any session IDs
-	// that were previously saved by agent processes.
+	// Write agents.json — all participants (online + offline), preserving
+	// session IDs that were previously saved by agent processes.
 	existing, _ := LoadAgents(dir)
 	sessionIDs := make(map[string]string)
 	for _, a := range existing {
@@ -72,7 +72,6 @@ func SaveRoom(dir string, room *Room) error {
 
 	participants := room.GetParticipants()
 	pdata := make([]ParticipantData, 0, len(participants))
-	seen := make(map[string]bool)
 	for _, cc := range participants {
 		pd := ParticipantData{
 			Name:      cc.Name,
@@ -82,25 +81,10 @@ func SaveRoom(dir string, room *Room) error {
 			AgentType: cc.AgentType,
 			Source:    cc.Source,
 		}
-		// Preserve existing session ID.
 		if sid, ok := sessionIDs[cc.Name]; ok {
 			pd.SessionID = sid
 		}
 		pdata = append(pdata, pd)
-		seen[cc.Name] = true
-	}
-
-	// Preserve saved agents that haven't reconnected yet (e.g. after resume).
-	for _, sa := range room.SavedAgents {
-		if !seen[sa.Name] {
-			pd := sa
-			// Use latest session ID from disk if available.
-			if sid, ok := sessionIDs[sa.Name]; ok {
-				pd.SessionID = sid
-			}
-			pdata = append(pdata, pd)
-			seen[sa.Name] = true
-		}
 	}
 
 	if err := writeJSON(filepath.Join(dir, "agents.json"), pdata); err != nil {
@@ -111,8 +95,7 @@ func SaveRoom(dir string, room *Room) error {
 }
 
 // LoadRoom loads a Room from a previously saved directory.
-// It restores the topic and message history. Participants are not restored
-// (the room starts empty).
+// It restores the topic, message history, and all participants as offline.
 func LoadRoom(dir string) (*Room, error) {
 	var rd RoomData
 	if err := readJSON(filepath.Join(dir, "room.json"), &rd); err != nil {
@@ -132,9 +115,19 @@ func LoadRoom(dir string) (*Room, error) {
 		room.seq = msgs[len(msgs)-1].Seq
 	}
 
-	// Load saved agents so rejoining agents can recover their role.
+	// Restore all saved agents as offline participants.
 	agents, _ := LoadAgents(dir)
-	room.SavedAgents = agents
+	for _, a := range agents {
+		room.Participants[a.Name] = &ClientConn{
+			Name:      a.Name,
+			Role:      a.Role,
+			Directory: a.Directory,
+			Repo:      a.Repo,
+			AgentType: a.AgentType,
+			Source:    a.Source,
+			Online:    false,
+		}
+	}
 
 	return room, nil
 }

--- a/internal/server/persistence_test.go
+++ b/internal/server/persistence_test.go
@@ -369,9 +369,17 @@ func TestSaveRoom_PreservesSavedAgentsWhenNoParticipants(t *testing.T) {
 		t.Fatalf("SaveAgents: %v", err)
 	}
 
-	// Resume: LoadRoom populates SavedAgents but Participants is empty.
+	// Resume: Add them back as offline participants representing previously saved agents.
 	room := NewRoom("topic")
-	room.SavedAgents = prev
+	for _, a := range prev {
+		room.Participants[a.Name] = &ClientConn{
+			Name:      a.Name,
+			Role:      a.Role,
+			AgentType: a.AgentType,
+			Source:    a.Source,
+			Online:    false,
+		}
+	}
 
 	// SaveRoom should NOT destroy the saved agents even though no one is connected.
 	if err := SaveRoom(dir, room); err != nil {
@@ -412,7 +420,15 @@ func TestSaveRoom_PreservesPartialReconnect(t *testing.T) {
 	}
 
 	room := NewRoom("topic")
-	room.SavedAgents = prev
+	for _, a := range prev {
+		room.Participants[a.Name] = &ClientConn{
+			Name:      a.Name,
+			Role:      a.Role,
+			AgentType: a.AgentType,
+			Source:    a.Source,
+			Online:    false,
+		}
+	}
 
 	// Only claude reconnects.
 	cc := &ClientConn{Name: "claude", Role: "agent", AgentType: "claude", Source: "agent"}

--- a/internal/server/room.go
+++ b/internal/server/room.go
@@ -18,7 +18,6 @@ type Room struct {
 	AutoApprove  bool
 	Participants map[string]*ClientConn
 	Messages     []protocol.MessageParams
-	SavedAgents  []ParticipantData // loaded from agents.json on resume
 	seq          int
 	mu           sync.RWMutex
 }
@@ -31,6 +30,7 @@ type ClientConn struct {
 	Repo      string
 	AgentType string
 	Source    string
+	Online    bool
 	Send      chan []byte
 	Done      chan struct{}
 }
@@ -56,7 +56,9 @@ func newUUID() string {
 // Join adds cc to the room and returns a snapshot of the current room state,
 // including recent message history (up to 50 messages).
 // If cc.Send or cc.Done are nil they are initialized here.
-// Returns an error if a participant with the same name already exists.
+// If a participant with the same name exists and is offline, they are
+// reconnected (brought back online). If they are online, an error is returned.
+// When reconnecting, an empty Role in cc preserves the previously saved role.
 func (r *Room) Join(cc *ClientConn) (protocol.RoomStateParams, error) {
 	if cc.Send == nil {
 		cc.Send = make(chan []byte, 64)
@@ -66,11 +68,26 @@ func (r *Room) Join(cc *ClientConn) (protocol.RoomStateParams, error) {
 	}
 
 	r.mu.Lock()
-	if _, exists := r.Participants[cc.Name]; exists {
-		r.mu.Unlock()
-		return protocol.RoomStateParams{}, fmt.Errorf("name already taken: %q", cc.Name)
+	if existing, exists := r.Participants[cc.Name]; exists {
+		if existing.Online {
+			r.mu.Unlock()
+			return protocol.RoomStateParams{}, fmt.Errorf("name already taken: %q", cc.Name)
+		}
+		// Reconnecting offline participant — update and bring online.
+		if cc.Role != "" {
+			existing.Role = cc.Role
+		}
+		existing.Directory = cc.Directory
+		existing.Repo = cc.Repo
+		existing.AgentType = cc.AgentType
+		existing.Source = cc.Source
+		existing.Online = true
+		existing.Send = cc.Send
+		existing.Done = cc.Done
+	} else {
+		cc.Online = true
+		r.Participants[cc.Name] = cc
 	}
-	r.Participants[cc.Name] = cc
 	participants := r.snapshot()
 	topic := r.Topic
 	recent := r.recentMessages(50)
@@ -137,12 +154,14 @@ func (r *Room) RecentMessages(n int) []protocol.MessageParams {
 	return r.recentMessages(n)
 }
 
-// Leave removes the named participant from the room and closes their Done channel.
+// Leave marks the named participant as offline and closes their Done channel.
+// The participant remains in the map so mentions, colors, and persistence
+// continue to work.
 func (r *Room) Leave(name string) {
 	r.mu.Lock()
 	cc, ok := r.Participants[name]
 	if ok {
-		delete(r.Participants, name)
+		cc.Online = false
 	}
 	r.mu.Unlock()
 
@@ -168,10 +187,12 @@ func (r *Room) Broadcast(from, source, role string, content protocol.Content, _ 
 	}
 	r.Messages = append(r.Messages, msg)
 
-	// Collect send channels while holding the lock to avoid races.
+	// Collect send channels for online participants only.
 	targets := make([]chan []byte, 0, len(r.Participants))
 	for _, cc := range r.Participants {
-		targets = append(targets, cc.Send)
+		if cc.Online {
+			targets = append(targets, cc.Send)
+		}
 	}
 	r.mu.Unlock()
 
@@ -271,6 +292,7 @@ func (r *Room) snapshot() []protocol.Participant {
 			Repo:      cc.Repo,
 			AgentType: cc.AgentType,
 			Source:    cc.Source,
+			Online:    cc.Online,
 		})
 	}
 	return out
@@ -285,13 +307,28 @@ func (r *Room) GetMessages() []protocol.MessageParams {
 	return out
 }
 
-// GetParticipants returns a snapshot of the current participants, safe for concurrent use.
+// GetParticipants returns a snapshot of all participants (online and offline),
+// safe for concurrent use.
 func (r *Room) GetParticipants() []*ClientConn {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	out := make([]*ClientConn, 0, len(r.Participants))
 	for _, cc := range r.Participants {
 		out = append(out, cc)
+	}
+	return out
+}
+
+// GetOnlineParticipants returns only the online participants, safe for
+// concurrent use.
+func (r *Room) GetOnlineParticipants() []*ClientConn {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]*ClientConn, 0, len(r.Participants))
+	for _, cc := range r.Participants {
+		if cc.Online {
+			out = append(out, cc)
+		}
 	}
 	return out
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -96,20 +96,9 @@ func (s *Server) handleConn(conn net.Conn) {
 				source = "agent"
 			}
 
-			// If the agent's role is the default, check saved agents for their prior role.
-			role := params.Role
-			if role == "agent" || role == "" {
-				for _, sa := range s.room.SavedAgents {
-					if sa.Name == params.Name && sa.Role != "" {
-						role = sa.Role
-						break
-					}
-				}
-			}
-
 			cc = &ClientConn{
 				Name:      params.Name,
-				Role:      role,
+				Role:      params.Role,
 				Directory: params.Directory,
 				Repo:      params.Repo,
 				AgentType: params.AgentType,
@@ -135,10 +124,18 @@ func (s *Server) handleConn(conn net.Conn) {
 				_, _ = conn.Write(data)
 			}
 
-			// Notify other participants.
+			// Notify other participants. Use the effective role from the
+			// room state (may differ from params.Role on reconnection).
+			effectiveRole := params.Role
+			for _, p := range state.Participants {
+				if p.Name == params.Name {
+					effectiveRole = p.Role
+					break
+				}
+			}
 			jp := protocol.JoinedParams{
 				Name:      params.Name,
-				Role:      role,
+				Role:      effectiveRole,
 				Directory: params.Directory,
 				Repo:      params.Repo,
 				AgentType: params.AgentType,

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -275,7 +275,7 @@ func (a *App) handleServerMsg(raw *protocol.RawMessage) {
 	case "room.left":
 		var params protocol.LeftParams
 		if err := json.Unmarshal(raw.Params, &params); err == nil {
-			a.sidebar.RemoveParticipant(params.Name)
+			a.sidebar.SetParticipantOffline(params.Name)
 		}
 
 	case "room.status":

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -95,11 +95,11 @@ func TestHandleServerMsg_RoomJoined_AddsParticipant(t *testing.T) {
 	}
 }
 
-func TestHandleServerMsg_RoomLeft_RemovesParticipant(t *testing.T) {
+func TestHandleServerMsg_RoomLeft_SetsParticipantOffline(t *testing.T) {
 	a := makeApp()
 	a.sidebar.SetParticipants([]protocol.Participant{
-		{Name: "alice", Role: "human"},
-		{Name: "bot", Role: "agent"},
+		{Name: "alice", Role: "human", Online: true},
+		{Name: "bot", Role: "agent", Online: true},
 	})
 
 	left := protocol.LeftParams{Name: "bot"}
@@ -110,11 +110,11 @@ func TestHandleServerMsg_RoomLeft_RemovesParticipant(t *testing.T) {
 
 	a.handleServerMsg(raw)
 
-	if len(a.sidebar.participants) != 1 {
-		t.Fatalf("expected 1 participant after leave, got %d", len(a.sidebar.participants))
+	if len(a.sidebar.participants) != 2 {
+		t.Fatalf("expected 2 participants after leave, got %d", len(a.sidebar.participants))
 	}
-	if a.sidebar.participants[0].Name != "alice" {
-		t.Errorf("wrong participant remains: %s", a.sidebar.participants[0].Name)
+	if a.sidebar.participants[1].Name != "bot" || a.sidebar.participants[1].Online != false {
+		t.Errorf("expected bot to be marked offline: %+v", a.sidebar.participants[1])
 	}
 }
 

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -69,6 +69,16 @@ func (s *Sidebar) RemoveParticipant(name string) {
 	s.participants = filtered
 }
 
+// SetParticipantOffline marks a participant as offline rather than removing them.
+func (s *Sidebar) SetParticipantOffline(name string) {
+	for i, p := range s.participants {
+		if p.Name == name {
+			s.participants[i].Online = false
+			break
+		}
+	}
+}
+
 // View renders the sidebar as a string.
 func (s Sidebar) View() string {
 	innerWidth := s.width - 4 // account for border + padding
@@ -79,9 +89,26 @@ func (s Sidebar) View() string {
 	title := sidebarTitleStyle.Render("participants")
 	lines := []string{title}
 
+	// Sort: online participants first, then offline.
+	online := make([]protocol.Participant, 0, len(s.participants))
+	offline := make([]protocol.Participant, 0)
 	for _, p := range s.participants {
-		nameLine := nameStyle(p.Name, s.nameColors).Render(p.Name)
-		lines = append(lines, nameLine)
+		if p.Online {
+			online = append(online, p)
+		} else {
+			offline = append(offline, p)
+		}
+	}
+	sorted := append(online, offline...)
+
+	for _, p := range sorted {
+		if p.Online {
+			nameLine := nameStyle(p.Name, s.nameColors).Render(p.Name)
+			lines = append(lines, nameLine)
+		} else {
+			nameLine := offlineNameStyle.Render(p.Name + " (offline)")
+			lines = append(lines, nameLine)
+		}
 
 		// Show per-participant status when non-empty.
 		if status := s.statuses[p.Name]; status != "" {

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -64,4 +64,8 @@ var (
 	listeningStatusStyle = lipgloss.NewStyle().
 				Foreground(lipgloss.Color("#3fb950")).
 				Italic(true)
+
+	offlineNameStyle = lipgloss.NewStyle().
+				Foreground(colorDimText).
+				Italic(true)
 )

--- a/internal/tui/visual_test.go
+++ b/internal/tui/visual_test.go
@@ -48,12 +48,14 @@ func buildTestApp(t *testing.T, width, height int) App {
 		Name:   "sle",
 		Role:   "human",
 		Source: "human",
+		Online: true,
 	})
 	app.sidebar.AddParticipant(protocol.Participant{
 		Name:      "Alice",
 		Role:      "backend",
 		Directory: "/home/alice/project",
 		AgentType: "claude",
+		Online:    true,
 	})
 
 	// Fixed timestamp for determinism


### PR DESCRIPTION
Resolves #59.

This PR unifies the room participant list into a single `Participants` map with an **Online** boolean, removing `SavedAgents` entirely. This simplifies persistence and streamlines the user experience when participants disconnect and resume.