### PR TITLE
feat: YOLO mode visual indicator in status bar

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -272,6 +272,7 @@ func (a *App) handleServerMsg(raw *protocol.RawMessage) {
 		var params protocol.RoomStateParams
 		if err := json.Unmarshal(raw.Params, &params); err == nil {
 			a.sidebar.SetParticipants(params.Participants)
+			a.statusbar.SetYolo(params.AutoApprove)
 			if len(params.Messages) > 0 {
 				a.chat.SetLoading(true)
 				a.pendingHistory = params.Messages

--- a/internal/tui/statusbar.go
+++ b/internal/tui/statusbar.go
@@ -9,6 +9,7 @@ import (
 // StatusBar renders the bottom status line.
 type StatusBar struct {
 	connected bool
+	yolo      bool
 	width     int
 }
 
@@ -27,6 +28,11 @@ func (s *StatusBar) SetConnected(c bool) {
 	s.connected = c
 }
 
+// SetYolo sets whether the room is in yolo/auto-approve mode.
+func (s *StatusBar) SetYolo(y bool) {
+	s.yolo = y
+}
+
 // View renders the status bar as a single line.
 func (s StatusBar) View() string {
 	barBg := lipgloss.NewStyle().Background(colorSidebarBg)
@@ -37,8 +43,16 @@ func (s StatusBar) View() string {
 		Foreground(colorText).
 		Padding(0, 1)
 
-	// Left: just help.
+	// Left: help, plus optional YOLO badge.
 	left := helpStyle.Render("? help")
+	if s.yolo {
+		yoloStyle := lipgloss.NewStyle().
+			Bold(true).
+			Background(colorStatusBarBg).
+			Foreground(lipgloss.Color("#d29922")).
+			Padding(0, 1)
+		left += yoloStyle.Render("⚡ YOLO")
+	}
 
 	// Right: connection status.
 	var right string

--- a/internal/tui/statusbar_test.go
+++ b/internal/tui/statusbar_test.go
@@ -30,3 +30,23 @@ func TestStatusBarShowsHelp(t *testing.T) {
 		t.Errorf("expected '? help' in output, got: %q", stripANSI(out))
 	}
 }
+
+func TestStatusBarShowsYoloBadgeWhenActive(t *testing.T) {
+	sb := NewStatusBar()
+	sb.SetWidth(80)
+	sb.SetYolo(true)
+	out := sb.View()
+	if !contains(out, "YOLO") {
+		t.Errorf("expected 'YOLO' badge in output when yolo=true, got: %q", stripANSI(out))
+	}
+}
+
+func TestStatusBarHidesYoloBadgeWhenInactive(t *testing.T) {
+	sb := NewStatusBar()
+	sb.SetWidth(80)
+	sb.SetYolo(false)
+	out := sb.View()
+	if contains(out, "YOLO") {
+		t.Errorf("expected no 'YOLO' badge when yolo=false, got: %q", stripANSI(out))
+	}
+}


### PR DESCRIPTION
## Summary

- Adds amber `⚡ YOLO` badge to the bottom status bar when the room is in auto-approve mode
- Badge disappears when yolo mode is off
- Wires `AutoApprove` from `room.state` into `StatusBar.SetYolo` in `app.go`

## Test plan

- [ ] `TestStatusBarShowsYoloBadgeWhenActive` — badge appears when `SetYolo(true)`
- [ ] `TestStatusBarHidesYoloBadgeWhenInactive` — no badge when `SetYolo(false)`
- [ ] All existing tests pass (`go test ./...`)

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)