### PR TITLE
fix: joined participants shown offline & YOLO missing on agent panel

### DIFF
--- a/cmd/parley/main.go
+++ b/cmd/parley/main.go
@@ -404,6 +404,7 @@ func runJoin(cmd *cobra.Command, args []string) error {
 
 	app := tui.NewApp(topic, joinPort, tui.InputModeAgent, joinName, nil, roomState.Participants...)
 	app.SetAgent(joinName, joinRole)
+	app.SetYolo(roomState.AutoApprove)
 	p := tea.NewProgram(app, tea.WithAltScreen(), tea.WithMouseCellMotion())
 
 	// Bridge network → TUI + agent driver.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -86,6 +86,11 @@ func NewApp(topic string, port int, mode InputMode, _ string, sendFn func(string
 	return a
 }
 
+// SetYolo sets whether the room is in yolo/auto-approve mode on the status bar.
+func (a *App) SetYolo(y bool) {
+	a.statusbar.SetYolo(y)
+}
+
 // SetAgent configures the agent name and role shown in the topbar.
 func (a *App) SetAgent(name, role string) {
 	a.topbar.SetAgent(name, role)
@@ -315,6 +320,7 @@ func (a *App) handleServerMsg(raw *protocol.RawMessage) {
 				Directory: params.Directory,
 				Repo:      params.Repo,
 				AgentType: params.AgentType,
+				Online:    true,
 			})
 		}
 

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -121,6 +121,9 @@ func TestHandleServerMsg_RoomJoined_AddsParticipant(t *testing.T) {
 	if a.sidebar.participants[0].Name != "carol" {
 		t.Errorf("unexpected participant name: %s", a.sidebar.participants[0].Name)
 	}
+	if !a.sidebar.participants[0].Online {
+		t.Errorf("expected joined participant to be online")
+	}
 }
 
 func TestHandleServerMsg_RoomLeft_SetsParticipantOffline(t *testing.T) {


### PR DESCRIPTION
## Summary
- **Offline bug**: `room.joined` handler constructed `Participant` without `Online: true` — Go zero value (`false`) meant every joining participant appeared offline to other clients' sidebars
- **YOLO bug**: `runJoin` consumed `room.state` before the TUI started to extract topic/participants, so `AutoApprove` was never propagated to the agent's status bar

## Test plan
- [ ] Host a session with `--yolo`, join with an agent — verify agent sidebar shows participant online AND status bar shows YOLO
- [ ] Existing test `TestHandleServerMsg_RoomJoined_AddsParticipant` now asserts `Online == true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)