### PR TITLE
feat(tui): migrate App to event-sourced state from room.State

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -230,10 +230,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.chat.SetLoading(false)
 		a.chat.LoadMessages(m.Messages)
 		a.statusbar.SetYolo(a.roomState != nil && a.roomState.AutoApprove())
-		if isAnyGenerating(a.localActivities) {
-			return a, spinnerTick()
-		}
-		return a, nil
+		return a, a.maybeStartSpinnerFromActivities()
 
 	case room.MessageReceived:
 		a.localMessages = append(a.localMessages, m.Message)
@@ -243,21 +240,12 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case room.ParticipantsChanged:
 		a.localParticipants = m.Participants
 		a.sidebar.SetParticipants(m.Participants)
-		if isAnyGenerating(a.localActivities) {
-			return a, spinnerTick()
-		}
-		return a, nil
+		return a, a.maybeStartSpinnerFromActivities()
 
 	case room.ParticipantActivityChanged:
 		a.localActivities[m.Name] = m.Activity
 		a.sidebar.SetParticipantStatus(m.Name, activityToString(m.Activity))
-		if m.Activity == room.ActivityGenerating {
-			if !a.spinnerActive {
-				a.spinnerActive = true
-				return a, spinnerTick()
-			}
-		}
-		return a, nil
+		return a, a.maybeStartSpinnerFromActivities()
 
 	case room.ErrorOccurred:
 		a.chat.AddMessage(systemMessage(m.Error.Error()))
@@ -529,6 +517,19 @@ func (a *App) handleServerMsg(raw *protocol.RawMessage) {
 			a.sidebar.SetParticipantStatus(params.Name, params.Status)
 		}
 	}
+}
+
+// maybeStartSpinnerFromActivities checks if any participant is generating and
+// starts the spinner tick if not already running. Used by room event handlers.
+func (a *App) maybeStartSpinnerFromActivities() tea.Cmd {
+	if a.spinnerActive {
+		return nil
+	}
+	if isAnyGenerating(a.localActivities) {
+		a.spinnerActive = true
+		return spinnerTick()
+	}
+	return nil
 }
 
 // isAnyGenerating returns true if any participant has ActivityGenerating.

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -504,14 +504,8 @@ func TestApp_FilterSuggestions_NarrowsList(t *testing.T) {
 
 // ---- Room event handlers (Task 7) ------------------------------------------
 
-func makeAppWithRoomState() App {
-	app := makeApp()
-	app.localActivities = make(map[string]room.Activity)
-	return app
-}
-
 func TestApp_RoomMessageReceived_AddsToChat(t *testing.T) {
-	a := makeAppWithRoomState()
+	a := makeApp()
 	msg := protocol.MessageParams{
 		From:    "alice",
 		Content: []protocol.Content{{Type: "text", Text: "hello"}},
@@ -519,16 +513,21 @@ func TestApp_RoomMessageReceived_AddsToChat(t *testing.T) {
 	model, _ := a.Update(room.MessageReceived{Message: msg})
 	a = model.(App)
 
+	// Verify local state
 	if len(a.localMessages) != 1 {
 		t.Fatalf("expected 1 local message, got %d", len(a.localMessages))
 	}
 	if a.localMessages[0].From != "alice" {
 		t.Fatalf("expected from alice, got %s", a.localMessages[0].From)
 	}
+	// Verify dual-write to chat component
+	if len(a.chat.messages) != 1 {
+		t.Fatalf("expected 1 chat message, got %d", len(a.chat.messages))
+	}
 }
 
 func TestApp_RoomHistoryLoaded_BulkReplacesState(t *testing.T) {
-	a := makeAppWithRoomState()
+	a := makeApp()
 	model, _ := a.Update(room.HistoryLoaded{
 		Messages: []protocol.MessageParams{
 			{From: "alice", Content: []protocol.Content{{Type: "text", Text: "hi"}}},
@@ -544,6 +543,7 @@ func TestApp_RoomHistoryLoaded_BulkReplacesState(t *testing.T) {
 	})
 	a = model.(App)
 
+	// Verify local state
 	if len(a.localMessages) != 2 {
 		t.Fatalf("expected 2 messages, got %d", len(a.localMessages))
 	}
@@ -553,10 +553,17 @@ func TestApp_RoomHistoryLoaded_BulkReplacesState(t *testing.T) {
 	if a.localActivities["bob"] != room.ActivityGenerating {
 		t.Fatal("expected bob to be generating")
 	}
+	// Verify dual-write to components
+	if len(a.chat.messages) != 2 {
+		t.Fatalf("expected 2 chat messages, got %d", len(a.chat.messages))
+	}
+	if len(a.sidebar.participants) != 2 {
+		t.Fatalf("expected 2 sidebar participants, got %d", len(a.sidebar.participants))
+	}
 }
 
 func TestApp_RoomParticipantsChanged_UpdatesLocal(t *testing.T) {
-	a := makeAppWithRoomState()
+	a := makeApp()
 	model, _ := a.Update(room.ParticipantsChanged{
 		Participants: []protocol.Participant{
 			{Name: "alice", Online: true},
@@ -567,10 +574,14 @@ func TestApp_RoomParticipantsChanged_UpdatesLocal(t *testing.T) {
 	if len(a.localParticipants) != 1 {
 		t.Fatalf("expected 1 participant, got %d", len(a.localParticipants))
 	}
+	// Verify dual-write to sidebar
+	if len(a.sidebar.participants) != 1 {
+		t.Fatalf("expected 1 sidebar participant, got %d", len(a.sidebar.participants))
+	}
 }
 
 func TestApp_RoomParticipantActivityChanged_UpdatesLocal(t *testing.T) {
-	a := makeAppWithRoomState()
+	a := makeApp()
 	model, _ := a.Update(room.ParticipantActivityChanged{
 		Name:     "claude",
 		Activity: room.ActivityGenerating,
@@ -580,10 +591,14 @@ func TestApp_RoomParticipantActivityChanged_UpdatesLocal(t *testing.T) {
 	if a.localActivities["claude"] != room.ActivityGenerating {
 		t.Fatal("expected claude to be generating")
 	}
+	// Verify dual-write to sidebar
+	if a.sidebar.statuses["claude"] != "generating" {
+		t.Fatalf("expected sidebar status 'generating', got %q", a.sidebar.statuses["claude"])
+	}
 }
 
 func TestApp_RoomErrorOccurred_AddsSystemMessage(t *testing.T) {
-	a := makeAppWithRoomState()
+	a := makeApp()
 	model, _ := a.Update(room.ErrorOccurred{
 		Error: fmt.Errorf("test error"),
 	})


### PR DESCRIPTION
## Summary

- Adds TUI-local state fields (`localMessages`, `localParticipants`, `localActivities`) to App
- Handles room events in `Update`: `HistoryLoaded`, `MessageReceived`, `ParticipantsChanged`, `ParticipantActivityChanged`, `ErrorOccurred`
- When `roomState` is set, `ServerMsg` case delegates to room.State (no-op since events arrive via channel bridge). Old `handleServerMsg` path kept as fallback for tests without room.State.
- Events update both TUI-local state AND existing components (sidebar, chat) for backward compatibility

Closes #80

## Test plan

- [x] 5 new tests for room event handlers (all pass)
- [x] `go test ./... -timeout 30s` — full suite green, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)