### PR TITLE
refactor(tui): replace suggestion system with Input FSM

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -101,6 +101,10 @@ func NewApp(topic string, port int, mode InputMode, _ string, sendFn func(string
 	if len(participants) > 0 {
 		a.sidebar.SetParticipants(participants)
 	}
+	// Callbacks are no-ops because Bubble Tea uses value semantics — the App
+	// is copied on every Update call, so closures captured here would mutate
+	// a stale copy. Suggestion population and hiding happen inline at the
+	// call sites in Update instead.
 	a.inputFSM = NewInputFSM(func(InputTrigger) {}, func() {})
 	return a
 }
@@ -421,8 +425,6 @@ func (a *App) maybeStartSpinner() tea.Cmd {
 	return nil
 }
 
-// checkSuggestionTrigger scans the current input value for a trigger character
-// and activates suggestions if found.
 // handleServerMsg dispatches an incoming RawMessage to the appropriate handler
 // based on its method.
 func (a *App) handleServerMsg(raw *protocol.RawMessage) {

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -433,11 +433,26 @@ func TestApp_AtTrigger_MidMessage(t *testing.T) {
 }
 
 func TestApp_AtTrigger_NotAfterAlpha(t *testing.T) {
-	// Trigger detection in Update prevents firing for "email@".
-	// FSM stays in Normal — no TriggerMention is fired.
 	a := makeApp()
+	a.localParticipants = []protocol.Participant{
+		{Name: "claude", Role: "agent", Online: true},
+	}
+	// Give the app a size so key events are processed.
+	model, _ := a.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	a = model.(App)
+
+	// Simulate typing "email@" — the '@' follows an alpha character,
+	// so the trigger detection should NOT fire.
+	a.input.ta.SetValue("email@")
+	// Run the post-key trigger check by sending a key event.
+	model, _ = a.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'@'}})
+	a = model.(App)
+
 	if a.inputFSM.Current() != StateNormal {
-		t.Error("expected FSM in StateNormal by default")
+		t.Error("expected FSM in StateNormal — '@' after alpha should not trigger")
+	}
+	if a.suggestions.Visible() {
+		t.Error("expected suggestions NOT visible after 'email@'")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replaces ad-hoc `completionTrigger`/`completionStart` suggestion tracking with `InputFSM`
- Key handlers check `inputFSM.Current()` for routing instead of `suggestions.Visible()`
- Post-key trigger detection fires FSM transitions, then populates suggestions via dedicated methods
- Deletes 4 old methods: `checkSuggestionTrigger`, `updateSuggestionFilter`, `acceptSuggestion`, `dismissSuggestions`
- Net -11 lines (128 added, 139 removed)

Note: FSM callbacks are no-ops due to Bubble Tea's value semantics (App is copied on each Update). Instead, suggestion population happens inline after FSM transitions in the caller.

Closes #81

## Test plan

- [x] All 7 suggestion tests updated to use FSM + populate methods
- [x] `go test ./internal/tui/ -v` — all 108 tests pass
- [x] `go test ./... -timeout 30s` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)