### PR TITLE
refactor(tui): remove handleServerMsg and dead migration code

### DIFF
--- a/cmd/parley/main.go
+++ b/cmd/parley/main.go
@@ -243,7 +243,6 @@ func runHost(_ *cobra.Command, _ []string) error {
 		})
 		for msg := range c.Incoming() {
 			roomState.HandleServerMessage(msg)
-			p.Send(tui.ServerMsg{Raw: msg}) // keep old path working
 		}
 	}()
 
@@ -464,7 +463,6 @@ func runJoin(cmd *cobra.Command, args []string) error {
 
 		for msg := range c.Incoming() {
 			rs.HandleServerMessage(msg)
-			p.Send(tui.ServerMsg{Raw: msg})
 
 			if msg.Method == "room.message" {
 				var params protocol.MessageParams

--- a/internal/room/state_test.go
+++ b/internal/room/state_test.go
@@ -69,7 +69,7 @@ func TestParticipants_ReturnsCopy(t *testing.T) {
 
 	// Mutate the returned slice
 	got[0].Name = "mutated"
-	got = append(got, protocol.Participant{Name: "extra"})
+	_ = append(got, protocol.Participant{Name: "extra"})
 
 	// Internal state must be unchanged
 	if s.participants[0].Name != "alice" {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1,7 +1,6 @@
 package tui
 
 import (
-	"encoding/json"
 	"strings"
 	"time"
 
@@ -14,11 +13,6 @@ import (
 )
 
 const sidebarWidth = 30
-
-// ServerMsg wraps an incoming raw protocol message from the network.
-type ServerMsg struct {
-	Raw *protocol.RawMessage
-}
 
 // SpinnerTickMsg triggers a sidebar spinner frame advance.
 type SpinnerTickMsg struct{}
@@ -44,28 +38,22 @@ type LocalSystemMsg struct {
 	Text string
 }
 
-// HistoryLoadedMsg signals that message history has been loaded.
-type HistoryLoadedMsg struct {
-	Messages []protocol.MessageParams
-}
-
 // App is the root Bubble Tea model that composes all TUI components.
 type App struct {
-	topbar            TopBar
-	chat              Chat
-	sidebar           Sidebar
-	input             Input
-	statusbar         StatusBar
-	modal             *Modal                   // non-nil when a modal overlay is active
-	sendFn            func(string, []string)   // callback to send messages over network
-	registry          *command.Registry        // slash command registry (nil = no commands)
-	cmdCtx            command.Context          // context passed to slash commands
-	lastInputHeight   int                      // cached to avoid redundant re-layouts
-	pendingHistory    []protocol.MessageParams // set during room.state, loaded async
-	suggestions      Suggestions
-	inputFSM         *InputFSM
-	completionStart  int // cursor position where trigger character was typed
-	roomState        *room.State
+	topbar          TopBar
+	chat            Chat
+	sidebar         Sidebar
+	input           Input
+	statusbar       StatusBar
+	modal           *Modal                 // non-nil when a modal overlay is active
+	sendFn          func(string, []string) // callback to send messages over network
+	registry        *command.Registry      // slash command registry (nil = no commands)
+	cmdCtx          command.Context        // context passed to slash commands
+	lastInputHeight int                    // cached to avoid redundant re-layouts
+	suggestions     Suggestions
+	inputFSM        *InputFSM
+	completionStart int // cursor position where trigger character was typed
+	roomState       *room.State
 
 	// TUI-owned state, built from room events.
 	localMessages     []protocol.MessageParams
@@ -269,31 +257,6 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Self-terminates when no one is generating.
 		return a, nil
 
-	case ServerMsg:
-		if a.roomState != nil {
-			// room.State handles this via HandleServerMessage → emits events
-			// which arrive through the event bridge goroutine. Nothing to do here.
-			return a, nil
-		}
-		// Fallback for tests/contexts without room.State.
-		a.handleServerMsg(m.Raw)
-		if len(a.pendingHistory) > 0 {
-			msgs := a.pendingHistory
-			a.pendingHistory = nil
-			return a, tea.Batch(
-				func() tea.Msg {
-					return HistoryLoadedMsg{Messages: msgs}
-				},
-				a.maybeStartSpinner(),
-			)
-		}
-		return a, a.maybeStartSpinner()
-
-	case HistoryLoadedMsg:
-		a.chat.SetLoading(false)
-		a.chat.LoadMessages(m.Messages)
-		return a, nil
-
 	case AgentTypingMsg:
 		a.input.SetAgentText(m.Text)
 		return a, nil
@@ -403,68 +366,6 @@ func (a *App) layout() {
 	a.input.SetWidth(a.width)
 	a.statusbar.SetWidth(a.width)
 	a.suggestions.SetWidth(a.width)
-}
-
-// maybeStartSpinner checks if any participant is generating and starts
-// the spinner tick. Used by the legacy ServerMsg fallback path.
-func (a *App) maybeStartSpinner() tea.Cmd {
-	for _, status := range a.sidebar.statuses {
-		if status == "generating" {
-			return spinnerTick()
-		}
-	}
-	return nil
-}
-
-// handleServerMsg dispatches an incoming RawMessage to the appropriate handler
-// based on its method.
-func (a *App) handleServerMsg(raw *protocol.RawMessage) {
-	if raw == nil {
-		return
-	}
-	switch raw.Method {
-	case "room.state":
-		var params protocol.RoomStateParams
-		if err := json.Unmarshal(raw.Params, &params); err == nil {
-			a.sidebar.SetParticipants(params.Participants)
-			a.statusbar.SetYolo(params.AutoApprove)
-			if len(params.Messages) > 0 {
-				a.chat.SetLoading(true)
-				a.pendingHistory = params.Messages
-			}
-		}
-
-	case "room.message":
-		var params protocol.MessageParams
-		if err := json.Unmarshal(raw.Params, &params); err == nil {
-			a.chat.AddMessage(params)
-		}
-
-	case "room.joined":
-		var params protocol.JoinedParams
-		if err := json.Unmarshal(raw.Params, &params); err == nil {
-			a.sidebar.AddParticipant(protocol.Participant{
-				Name:      params.Name,
-				Role:      params.Role,
-				Directory: params.Directory,
-				Repo:      params.Repo,
-				AgentType: params.AgentType,
-				Online:    true,
-			})
-		}
-
-	case "room.left":
-		var params protocol.LeftParams
-		if err := json.Unmarshal(raw.Params, &params); err == nil {
-			a.sidebar.SetParticipantOffline(params.Name)
-		}
-
-	case "room.status":
-		var params protocol.StatusParams
-		if err := json.Unmarshal(raw.Params, &params); err == nil {
-			a.sidebar.SetParticipantStatus(params.Name, params.Status)
-		}
-	}
 }
 
 // populateSlashSuggestions fills the suggestion list with available commands.

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -1,7 +1,6 @@
 package tui
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -12,19 +11,10 @@ import (
 	"github.com/khaiql/parley/internal/room"
 )
 
-// ---- handleServerMsg ---------------------------------------------------------
+// ---- Test helpers -----------------------------------------------------------
 
 func makeApp() App {
 	return NewApp("test-topic", 9000, InputModeHuman, "tester", nil)
-}
-
-func rawParams(t *testing.T, v interface{}) json.RawMessage {
-	t.Helper()
-	b, err := json.Marshal(v)
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
-	}
-	return b
 }
 
 // fakeRoom is a minimal RoomQuerier for modal integration testing.
@@ -51,186 +41,7 @@ func makeAppWithRegistry() App {
 	return model.(App)
 }
 
-func TestHandleServerMsg_RoomMessage_AddsToChat(t *testing.T) {
-	a := makeApp()
-
-	msg := protocol.MessageParams{
-		ID:   "msg-1",
-		From: "alice",
-		Role: "human",
-		Content: []protocol.Content{
-			{Type: "text", Text: "hello"},
-		},
-	}
-	raw := &protocol.RawMessage{
-		Method: "room.message",
-		Params: rawParams(t, msg),
-	}
-
-	a.handleServerMsg(raw)
-
-	if len(a.chat.messages) != 1 {
-		t.Fatalf("expected 1 message in chat, got %d", len(a.chat.messages))
-	}
-	if a.chat.messages[0].From != "alice" {
-		t.Errorf("unexpected From: %s", a.chat.messages[0].From)
-	}
-}
-
-func TestHandleServerMsg_RoomState_SetsParticipants(t *testing.T) {
-	a := makeApp()
-
-	state := protocol.RoomStateParams{
-		Topic: "test-topic",
-		Participants: []protocol.Participant{
-			{Name: "alice", Role: "human"},
-			{Name: "bot", Role: "agent"},
-		},
-	}
-	raw := &protocol.RawMessage{
-		Method: "room.state",
-		Params: rawParams(t, state),
-	}
-
-	a.handleServerMsg(raw)
-
-	if len(a.sidebar.participants) != 2 {
-		t.Fatalf("expected 2 participants, got %d", len(a.sidebar.participants))
-	}
-	if a.sidebar.participants[0].Name != "alice" {
-		t.Errorf("unexpected first participant: %s", a.sidebar.participants[0].Name)
-	}
-}
-
-func TestHandleServerMsg_RoomJoined_AddsParticipant(t *testing.T) {
-	a := makeApp()
-
-	joined := protocol.JoinedParams{
-		Name: "carol",
-		Role: "agent",
-	}
-	raw := &protocol.RawMessage{
-		Method: "room.joined",
-		Params: rawParams(t, joined),
-	}
-
-	a.handleServerMsg(raw)
-
-	if len(a.sidebar.participants) != 1 {
-		t.Fatalf("expected 1 participant, got %d", len(a.sidebar.participants))
-	}
-	if a.sidebar.participants[0].Name != "carol" {
-		t.Errorf("unexpected participant name: %s", a.sidebar.participants[0].Name)
-	}
-	if !a.sidebar.participants[0].Online {
-		t.Errorf("expected joined participant to be online")
-	}
-}
-
-func TestHandleServerMsg_RoomLeft_SetsParticipantOffline(t *testing.T) {
-	a := makeApp()
-	a.sidebar.SetParticipants([]protocol.Participant{
-		{Name: "alice", Role: "human", Online: true},
-		{Name: "bot", Role: "agent", Online: true},
-	})
-
-	left := protocol.LeftParams{Name: "bot"}
-	raw := &protocol.RawMessage{
-		Method: "room.left",
-		Params: rawParams(t, left),
-	}
-
-	a.handleServerMsg(raw)
-
-	if len(a.sidebar.participants) != 2 {
-		t.Fatalf("expected 2 participants after leave, got %d", len(a.sidebar.participants))
-	}
-	if a.sidebar.participants[1].Name != "bot" || a.sidebar.participants[1].Online != false {
-		t.Errorf("expected bot to be marked offline: %+v", a.sidebar.participants[1])
-	}
-}
-
-func TestHandleServerMsg_RoomStatus_UpdatesSidebarStatus(t *testing.T) {
-	a := makeApp()
-	a.sidebar.SetParticipants([]protocol.Participant{
-		{Name: "bot1", Role: "agent"},
-	})
-
-	sp := protocol.StatusParams{Name: "bot1", Status: "thinking…"}
-	raw := &protocol.RawMessage{
-		Method: "room.status",
-		Params: rawParams(t, sp),
-	}
-
-	a.handleServerMsg(raw)
-
-	if a.sidebar.statuses["bot1"] != "thinking…" {
-		t.Errorf("expected sidebar status 'thinking…' for bot1, got %q", a.sidebar.statuses["bot1"])
-	}
-}
-
-func TestHandleServerMsg_RoomStatusClear_ClearsSidebarStatus(t *testing.T) {
-	a := makeApp()
-	a.sidebar.SetParticipants([]protocol.Participant{
-		{Name: "bot1", Role: "agent"},
-	})
-	a.sidebar.SetParticipantStatus("bot1", "thinking…")
-
-	sp := protocol.StatusParams{Name: "bot1", Status: ""}
-	raw := &protocol.RawMessage{
-		Method: "room.status",
-		Params: rawParams(t, sp),
-	}
-
-	a.handleServerMsg(raw)
-
-	if a.sidebar.statuses["bot1"] != "" {
-		t.Errorf("expected empty status after clear, got %q", a.sidebar.statuses["bot1"])
-	}
-}
-
-func TestHandleServerMsg_RoomState_ReplayesMessageHistory(t *testing.T) {
-	a := makeApp()
-
-	state := protocol.RoomStateParams{
-		Topic: "test-topic",
-		Participants: []protocol.Participant{
-			{Name: "alice", Role: "human"},
-		},
-		Messages: []protocol.MessageParams{
-			{ID: "msg-1", From: "alice", Role: "human", Content: []protocol.Content{{Type: "text", Text: "hello"}}},
-			{ID: "msg-2", From: "alice", Role: "human", Content: []protocol.Content{{Type: "text", Text: "world"}}},
-		},
-	}
-	raw := &protocol.RawMessage{
-		Method: "room.state",
-		Params: rawParams(t, state),
-	}
-
-	a.handleServerMsg(raw)
-
-	// History is now loaded asynchronously: handleServerMsg sets pendingHistory,
-	// then Update dispatches HistoryLoadedMsg.
-	if len(a.pendingHistory) != 2 {
-		t.Fatalf("expected 2 pending messages after room.state, got %d", len(a.pendingHistory))
-	}
-
-	// Simulate the async load completing.
-	model, _ := a.Update(ServerMsg{Raw: raw})
-	a = model.(App)
-	model, _ = a.Update(HistoryLoadedMsg{Messages: state.Messages})
-	a = model.(App)
-
-	if len(a.chat.messages) != 2 {
-		t.Fatalf("expected 2 messages in chat after history load, got %d", len(a.chat.messages))
-	}
-	if a.chat.messages[0].From != "alice" {
-		t.Errorf("unexpected first message From: %s", a.chat.messages[0].From)
-	}
-	if a.chat.messages[1].Content[0].Text != "world" {
-		t.Errorf("unexpected second message text: %s", a.chat.messages[1].Content[0].Text)
-	}
-}
+// ---- Input integration -------------------------------------------------------
 
 func TestTypingDoesNotScrollChat(t *testing.T) {
 	a := makeApp()
@@ -272,22 +83,6 @@ func TestTypingDoesNotScrollChat(t *testing.T) {
 
 	if scrollAfter != scrollBefore {
 		t.Errorf("typing changed viewport scroll position: before=%d, after=%d", scrollBefore, scrollAfter)
-	}
-}
-
-func TestHandleServerMsg_NilRaw_NoOp(t *testing.T) {
-	a := makeApp()
-	// Should not panic.
-	a.handleServerMsg(nil)
-}
-
-func TestHandleServerMsg_UnknownMethod_NoOp(t *testing.T) {
-	a := makeApp()
-	raw := &protocol.RawMessage{Method: "unknown.method"}
-	// Should not panic.
-	a.handleServerMsg(raw)
-	if len(a.sidebar.participants) != 0 {
-		t.Error("expected no participants after unknown method")
 	}
 }
 


### PR DESCRIPTION
## Summary

Final cleanup for the TUI architecture refactor:

- Deletes `handleServerMsg` method (replaced by `room.State` event dispatch)
- Deletes `HistoryLoadedMsg` type and `pendingHistory` field
- Deletes `maybeStartSpinner` (old path, replaced by reactive self-terminating tick)
- Removes 9 old `TestHandleServerMsg_*` tests (covered by `internal/room/dispatch_test.go` + room event tests)
- Removes unused `json` import and `rawParams` test helper
- Fixes gofmt formatting and ineffassign lint warning
- **Net -294 lines** (19 added, 313 removed)

## Quality gates

- [x] `go build ./...` — clean
- [x] `go test ./... -timeout 30s -race` — all pass, no races
- [x] `grep -r "bubbletea|lipgloss|bubbles" internal/room/` — zero TUI imports in room package

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)