### PR TITLE
feat: replace [LISTENING] with [PASS] and improve anti-echo-chamber prompt

### DIFF
--- a/cmd/parley/join.go
+++ b/cmd/parley/join.go
@@ -314,7 +314,7 @@ func startAgentBridge(c *client.TCPClient, d driver.AgentDriver, p *tea.Program)
 				_ = c.SendStatus(joinName, protocol.StatusUsingTool(event.ToolName))
 			case driver.EventDone:
 				text := strings.TrimSpace(accumulated.String())
-				if driver.IsListeningSignal(text) {
+				if protocol.IsPassSignal(text) {
 					_ = c.SendStatus(joinName, protocol.StatusListening)
 				} else if text != "" {
 					mentions := protocol.ParseMentions(text)

--- a/internal/driver/claude.go
+++ b/internal/driver/claude.go
@@ -261,18 +261,6 @@ func parseStreamEvent(raw claudeRawEvent) (AgentEvent, bool) {
 }
 
 // ---------------------------------------------------------------------------
-// IsListeningSignal
-// ---------------------------------------------------------------------------
-
-// IsListeningSignal reports whether the agent's accumulated response text
-// should be treated as a silence signal rather than a chat message.
-// An agent outputs exactly "[LISTENING]" (on its own, possibly surrounded by
-// whitespace) when it decides not to respond to a message.
-func IsListeningSignal(text string) bool {
-	return strings.TrimSpace(text) == "[LISTENING]"
-}
-
-// ---------------------------------------------------------------------------
 // BuildInputMessage
 // ---------------------------------------------------------------------------
 

--- a/internal/driver/driver_test.go
+++ b/internal/driver/driver_test.go
@@ -533,10 +533,10 @@ func TestReadLoop_DefaultBufferFailsOnLargeLine(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// TestBuildSystemPrompt_ContainsListeningInstruction
+// TestBuildSystemPrompt_ContainsPassInstruction
 // ---------------------------------------------------------------------------
 
-func TestBuildSystemPrompt_ContainsListeningInstruction(t *testing.T) {
+func TestBuildSystemPrompt_ContainsPassInstruction(t *testing.T) {
 	cfg := AgentConfig{
 		Name:      "Alice",
 		Role:      "engineer",
@@ -547,47 +547,8 @@ func TestBuildSystemPrompt_ContainsListeningInstruction(t *testing.T) {
 		},
 	}
 	prompt := BuildSystemPrompt(cfg)
-	if !strings.Contains(prompt, "[LISTENING]") {
-		t.Errorf("expected system prompt to contain '[LISTENING]' instruction, got:\n%s", prompt)
-	}
-}
-
-// ---------------------------------------------------------------------------
-// TestIsListeningSignal
-// ---------------------------------------------------------------------------
-
-func TestIsListeningSignal_ExactMatch(t *testing.T) {
-	if !IsListeningSignal("[LISTENING]") {
-		t.Error("expected IsListeningSignal to return true for '[LISTENING]'")
-	}
-}
-
-func TestIsListeningSignal_WithWhitespace(t *testing.T) {
-	cases := []string{
-		"  [LISTENING]  ",
-		"\n[LISTENING]\n",
-		"\t[LISTENING]\t",
-		"[LISTENING]\n",
-	}
-	for _, c := range cases {
-		if !IsListeningSignal(c) {
-			t.Errorf("expected IsListeningSignal(%q) to return true", c)
-		}
-	}
-}
-
-func TestIsListeningSignal_FalseForOtherText(t *testing.T) {
-	cases := []string{
-		"",
-		"Hello world",
-		"I am [LISTENING] to you",
-		"[listening]",
-		"LISTENING",
-	}
-	for _, c := range cases {
-		if IsListeningSignal(c) {
-			t.Errorf("expected IsListeningSignal(%q) to return false", c)
-		}
+	if !strings.Contains(prompt, "[PASS]") {
+		t.Errorf("expected system prompt to contain '[PASS]' instruction, got:\n%s", prompt)
 	}
 }
 

--- a/internal/driver/gemini_test.go
+++ b/internal/driver/gemini_test.go
@@ -232,12 +232,12 @@ func TestParseGeminiLine_ThoughtTextPrefixFiltered(t *testing.T) {
 	}
 }
 
-func TestParseGeminiLine_ThoughtListeningFiltered(t *testing.T) {
-	// "[Thought: true][LISTENING]" should be filtered as thinking, not leak.
-	line := `{"type":"message","role":"assistant","content":"[Thought: true][LISTENING]","delta":true}`
+func TestParseGeminiLine_ThoughtPassFiltered(t *testing.T) {
+	// "[Thought: true][PASS]" should be filtered as thinking, not leak.
+	line := `{"type":"message","role":"assistant","content":"[Thought: true][PASS]","delta":true}`
 	event, ok := parseGeminiLine([]byte(line))
 	if !ok {
-		t.Fatal("expected thought+listening message to produce an event")
+		t.Fatal("expected thought+pass message to produce an event")
 	}
 	if event.Type != EventThinking {
 		t.Errorf("expected EventThinking, got %v", event.Type)

--- a/internal/driver/prompt.go
+++ b/internal/driver/prompt.go
@@ -32,7 +32,7 @@ func BuildSystemPrompt(config AgentConfig) string {
 - Do NOT respond just to agree — only add substance
 - If unsure whether to respond, default to staying silent
 - Keep responses focused and concise — this is a chat, not a monologue
-- If you decide not to respond to a message, output exactly [LISTENING] on a line by itself and nothing else
+- If you have nothing meaningful to add, output exactly [PASS] on a line by itself and nothing else. Use [PASS] when: (a) you want to skip responding, (b) the host has asked you to stop chiming in, or (c) your system requires you to always output something — [PASS] is the right way to skip your turn without polluting the chat
 
 JOINING:
 - When you first join, just say a brief hello (e.g. "Hi, I'm here to help with X"). Do NOT ask questions or @-mention anyone.
@@ -48,6 +48,13 @@ CONVERSATION DISCIPLINE:
 - Do NOT ask a question in return unless it is genuinely needed to do your work
 - Avoid back-and-forth ping-pong — say what you need to say, then stop
 - The human will direct the conversation. Wait for direction rather than creating your own threads
+
+VOICE AND OPINION:
+- You have your own perspective — express it. Do not just echo or validate what others say.
+- If you disagree, say so clearly and explain why. Disagreement moves the conversation forward; agreement without substance does not.
+- Question assumptions when something seems wrong or incomplete. Skepticism is more valuable than agreement.
+- Think before you answer. It is better to slow down and say something considered than to respond immediately with something empty.
+- Do not be a yes-man. If someone's plan has a flaw, name it. If an idea is good, say specifically why — not just "great idea!"
 
 When you respond, just write your message directly. Do not prefix it with your name.`)
 

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -183,6 +183,15 @@ func IsUsingTool(status string) bool {
 	return status == "using tool" || len(status) > 7 && status[:7] == "using: "
 }
 
+// IsPassSignal reports whether the agent's accumulated response text is a
+// [PASS] control signal. Agents output exactly "[PASS]" (optionally surrounded
+// by whitespace) when they have nothing meaningful to add and want to skip
+// their turn. This is a pure control signal — it must never be broadcast,
+// stored in message history, or rendered in the UI.
+func IsPassSignal(text string) bool {
+	return strings.TrimSpace(text) == "[PASS]"
+}
+
 // StatusParams is the params payload for a "room.status" notification.
 // Status is a short description of what the participant is doing, e.g.
 // "thinking", "using: Read", or "" to indicate idle.

--- a/internal/protocol/protocol_test.go
+++ b/internal/protocol/protocol_test.go
@@ -358,3 +358,43 @@ func TestNormalizeAgentType(t *testing.T) {
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// TestIsPassSignal
+// ---------------------------------------------------------------------------
+
+func TestIsPassSignal_ExactMatch(t *testing.T) {
+	if !protocol.IsPassSignal("[PASS]") {
+		t.Error("expected IsPassSignal to return true for '[PASS]'")
+	}
+}
+
+func TestIsPassSignal_WithWhitespace(t *testing.T) {
+	cases := []string{
+		"  [PASS]  ",
+		"\n[PASS]\n",
+		"\t[PASS]\t",
+		"[PASS]\n",
+	}
+	for _, c := range cases {
+		if !protocol.IsPassSignal(c) {
+			t.Errorf("expected IsPassSignal(%q) to return true", c)
+		}
+	}
+}
+
+func TestIsPassSignal_FalseForOtherText(t *testing.T) {
+	cases := []string{
+		"",
+		"Hello world",
+		"I am [PASS] on this",
+		"[pass]",
+		"PASS",
+		"[LISTENING]",
+	}
+	for _, c := range cases {
+		if protocol.IsPassSignal(c) {
+			t.Errorf("expected IsPassSignal(%q) to return false", c)
+		}
+	}
+}

--- a/internal/room/dispatch.go
+++ b/internal/room/dispatch.go
@@ -66,6 +66,11 @@ func (s *State) HandleServerMessage(raw *protocol.RawMessage) {
 			s.emit(ErrorOccurred{Error: err})
 			return
 		}
+		// Defense-in-depth: drop [PASS] signals even if they somehow reach
+		// the client. The server should have filtered these already.
+		if len(params.Content) > 0 && protocol.IsPassSignal(params.Content[0].Text) {
+			return
+		}
 		s.messages = append(s.messages, params)
 		s.emit(MessageReceived{Message: params})
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -213,6 +213,11 @@ func (s *TCPServer) handleConn(conn net.Conn) {
 			if len(params.Content) == 0 {
 				continue
 			}
+			// Drop [PASS] signals — they are pure control signals that must
+			// never be stored, broadcast, or shown in any UI.
+			if protocol.IsPassSignal(params.Content[0].Text) {
+				continue
+			}
 
 			s.mu.Lock()
 			msg := s.state.AddMessage(name, source, role, params.Content[0])

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -539,3 +539,82 @@ func TestRoomLeftBroadcast(t *testing.T) {
 		t.Fatal("alice never received room.left notification for bob")
 	}
 }
+
+// TestPassSignalDropped verifies that a [PASS] message is silently dropped by
+// the server — it must not be broadcast to other clients or stored in history.
+func TestPassSignalDropped(t *testing.T) {
+	s := newTestServer(t)
+
+	// Connect alice
+	connAlice := dialServer(t, s.Addr())
+	scAlice := newScanner(connAlice)
+	sendLine(t, connAlice, protocol.NewNotification(protocol.MethodJoin, protocol.JoinParams{
+		Name: "alice",
+		Role: "user",
+	}))
+	readLine(t, scAlice) // consume room.state
+
+	// Connect bob
+	connBob := dialServer(t, s.Addr())
+	sendLine(t, connBob, protocol.NewNotification(protocol.MethodJoin, protocol.JoinParams{
+		Name: "bob",
+		Role: "agent",
+	}))
+
+	// Drain alice's notification backlog (bob joined, system msg).
+	drainConn(t, connAlice, scAlice, 500*time.Millisecond)
+
+	// Bob sends [PASS]
+	sendLine(t, connBob, protocol.NewNotification(protocol.MethodSend, protocol.SendParams{
+		Content: []protocol.Content{{Type: "text", Text: "[PASS]"}},
+	}))
+
+	// Alice should receive nothing (no room.message with [PASS]).
+	deadline := time.Now().Add(300 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		connAlice.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+		if !scAlice.Scan() {
+			break
+		}
+		connAlice.SetReadDeadline(time.Time{})
+		var raw protocol.RawMessage
+		if err := json.Unmarshal(scAlice.Bytes(), &raw); err != nil {
+			continue
+		}
+		if raw.Method == protocol.MethodMessage {
+			var msg protocol.MessageParams
+			if err := json.Unmarshal(raw.Params, &msg); err != nil {
+				continue
+			}
+			for _, c := range msg.Content {
+				if c.Text == "[PASS]" {
+					t.Error("server broadcast a [PASS] message — it should have been dropped")
+				}
+			}
+		}
+	}
+	connAlice.SetReadDeadline(time.Time{})
+
+	// Also verify [PASS] is not in the server's stored history.
+	snap := s.Snapshot()
+	for _, m := range snap.Messages {
+		for _, c := range m.Content {
+			if c.Text == "[PASS]" {
+				t.Error("server stored a [PASS] message in room history — it should have been dropped")
+			}
+		}
+	}
+}
+
+// drainConn reads and discards all messages from scConn until it times out.
+func drainConn(t *testing.T, conn net.Conn, sc *bufio.Scanner, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		conn.SetReadDeadline(time.Now().Add(50 * time.Millisecond))
+		if !sc.Scan() {
+			break
+		}
+	}
+	conn.SetReadDeadline(time.Time{})
+}


### PR DESCRIPTION
Fixes #115

## Summary
- **`[PASS]` signal**: Replaces `[LISTENING]` as the silence token agents output when they have nothing to add. Agents like Rovodev (which must always produce output) can now output `[PASS]` to skip their turn — the join bridge intercepts it and does not send it to the server, breaking ping-pong loops between two agent instances.
- **`IsPassSignal`**: Renames `IsListeningSignal` → `IsPassSignal` in `internal/driver/claude.go` and updates all callers and tests.
- **Anti-echo-chamber prompt**: Adds a new `VOICE AND OPINION` section to the system prompt encouraging agents to form their own perspective, disagree explicitly, question assumptions, and slow down rather than default to validation or agreement.

## Test plan
- [ ] All existing tests pass (`go test ./... -race`)
- [ ] `TestIsPassSignal_*` tests verify `[PASS]` is correctly recognized (and `[LISTENING]` is not)
- [ ] `TestBuildSystemPrompt_ContainsPassInstruction` verifies prompt contains `[PASS]`
- [ ] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)